### PR TITLE
Fix buffer overflow regression with QStringList

### DIFF
--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -45,8 +45,8 @@ jobs:
         path: ~/.cache/go-build
         key: linux64-gocache
     
-    - name: Linux64 bindings compile
-      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/linux64:latest /bin/bash -c 'cd qt && go build'
+    - name: Linux64 bindings compile and test
+      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/linux64:latest /bin/bash -c 'cd qt && go build && cd ../examples/marshalling && env QT_QPA_PLATFORM=offscreen go test -v'
     
   miqt_win64:
     runs-on: ubuntu-22.04

--- a/cmd/genbindings/emitgo.go
+++ b/cmd/genbindings/emitgo.go
@@ -291,8 +291,17 @@ func (gfs *goFileState) emitParameterGo2CABIForwarding(p CppParameter) (preamble
 		gfs.imports["runtime"] = struct{}{}
 		gfs.imports["unsafe"] = struct{}{}
 
-		preamble += "// For the C ABI, malloc a C array of raw pointers\n"
-		preamble += nameprefix + "_CArray := (*[0xffff]" + listType.parameterTypeCgo() + ")(C.malloc(C.size_t(8 * len(" + p.ParameterName + "))))\n"
+		var mallocSize string
+		if listType.ParameterType == "QString" || listType.ParameterType == "QByteArray" {
+			preamble += "// For the C ABI, malloc a C array of structs\n"
+			mallocSize = "int(unsafe.Sizeof(C.struct_miqt_string{}))"
+
+		} else {
+			preamble += "// For the C ABI, malloc a C array of raw pointers\n"
+			mallocSize = "8"
+		}
+
+		preamble += nameprefix + "_CArray := (*[0xffff]" + listType.parameterTypeCgo() + ")(C.malloc(C.size_t(" + mallocSize + " * len(" + p.ParameterName + "))))\n"
 		preamble += "defer C.free(unsafe.Pointer(" + nameprefix + "_CArray))\n"
 
 		preamble += "for i := range " + p.ParameterName + "{\n"

--- a/examples/marshalling/marshalling_test.go
+++ b/examples/marshalling/marshalling_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/mappu/miqt/qt"
 )
 
-func TestMarshalling(t *testing.T) {
-
-	qt.NewQApplication(os.Args)
+func testMarshalling(t *testing.T) {
 
 	// Bool
 	t.Run("Bool", func(t *testing.T) {
@@ -107,5 +105,16 @@ func TestMarshalling(t *testing.T) {
 		}
 
 	})
+}
+
+func TestMarshalling(t *testing.T) {
+
+	qt.NewQApplication(os.Args)
+
+	// In case of heap corruption, run the whole test multiple times.
+
+	for i := 0; i < 5; i++ {
+		testMarshalling(t)
+	}
 
 }

--- a/qt/gen_qcborarray.go
+++ b/qt/gen_qcborarray.go
@@ -329,8 +329,8 @@ func (this *QCborArray) OperatorShiftLeft(v *QCborValue) *QCborArray {
 }
 
 func QCborArray_FromStringList(list []string) *QCborArray {
-	// For the C ABI, malloc a C array of raw pointers
-	list_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(list))))
+	// For the C ABI, malloc a C array of structs
+	list_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(list))))
 	defer C.free(unsafe.Pointer(list_CArray))
 	for i := range list {
 		list_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qcombobox.go
+++ b/qt/gen_qcombobox.go
@@ -342,8 +342,8 @@ func (this *QComboBox) AddItem2(icon *QIcon, text string) {
 }
 
 func (this *QComboBox) AddItems(texts []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	texts_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(texts))))
+	// For the C ABI, malloc a C array of structs
+	texts_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(texts))))
 	defer C.free(unsafe.Pointer(texts_CArray))
 	for i := range texts {
 		texts_i_ms := C.struct_miqt_string{}
@@ -374,8 +374,8 @@ func (this *QComboBox) InsertItem2(index int, icon *QIcon, text string) {
 }
 
 func (this *QComboBox) InsertItems(index int, texts []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	texts_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(texts))))
+	// For the C ABI, malloc a C array of structs
+	texts_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(texts))))
 	defer C.free(unsafe.Pointer(texts_CArray))
 	for i := range texts {
 		texts_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qcommandlineoption.go
+++ b/qt/gen_qcommandlineoption.go
@@ -61,8 +61,8 @@ func NewQCommandLineOption(name string) *QCommandLineOption {
 
 // NewQCommandLineOption2 constructs a new QCommandLineOption object.
 func NewQCommandLineOption2(names []string) *QCommandLineOption {
-	// For the C ABI, malloc a C array of raw pointers
-	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(names))))
+	// For the C ABI, malloc a C array of structs
+	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(names))))
 	defer C.free(unsafe.Pointer(names_CArray))
 	for i := range names {
 		names_i_ms := C.struct_miqt_string{}
@@ -93,8 +93,8 @@ func NewQCommandLineOption3(name string, description string) *QCommandLineOption
 
 // NewQCommandLineOption4 constructs a new QCommandLineOption object.
 func NewQCommandLineOption4(names []string, description string) *QCommandLineOption {
-	// For the C ABI, malloc a C array of raw pointers
-	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(names))))
+	// For the C ABI, malloc a C array of structs
+	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(names))))
 	defer C.free(unsafe.Pointer(names_CArray))
 	for i := range names {
 		names_i_ms := C.struct_miqt_string{}
@@ -161,8 +161,8 @@ func NewQCommandLineOption7(name string, description string, valueName string, d
 
 // NewQCommandLineOption8 constructs a new QCommandLineOption object.
 func NewQCommandLineOption8(names []string, description string, valueName string) *QCommandLineOption {
-	// For the C ABI, malloc a C array of raw pointers
-	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(names))))
+	// For the C ABI, malloc a C array of structs
+	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(names))))
 	defer C.free(unsafe.Pointer(names_CArray))
 	for i := range names {
 		names_i_ms := C.struct_miqt_string{}
@@ -187,8 +187,8 @@ func NewQCommandLineOption8(names []string, description string, valueName string
 
 // NewQCommandLineOption9 constructs a new QCommandLineOption object.
 func NewQCommandLineOption9(names []string, description string, valueName string, defaultValue string) *QCommandLineOption {
-	// For the C ABI, malloc a C array of raw pointers
-	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(names))))
+	// For the C ABI, malloc a C array of structs
+	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(names))))
 	defer C.free(unsafe.Pointer(names_CArray))
 	for i := range names {
 		names_i_ms := C.struct_miqt_string{}
@@ -276,8 +276,8 @@ func (this *QCommandLineOption) SetDefaultValue(defaultValue string) {
 }
 
 func (this *QCommandLineOption) SetDefaultValues(defaultValues []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	defaultValues_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(defaultValues))))
+	// For the C ABI, malloc a C array of structs
+	defaultValues_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(defaultValues))))
 	defer C.free(unsafe.Pointer(defaultValues_CArray))
 	for i := range defaultValues {
 		defaultValues_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qcommandlineparser.go
+++ b/qt/gen_qcommandlineparser.go
@@ -150,8 +150,8 @@ func (this *QCommandLineParser) ClearPositionalArguments() {
 }
 
 func (this *QCommandLineParser) Process(arguments []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -170,8 +170,8 @@ func (this *QCommandLineParser) ProcessWithApp(app *QCoreApplication) {
 }
 
 func (this *QCommandLineParser) Parse(arguments []string) bool {
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qcompleter.go
+++ b/qt/gen_qcompleter.go
@@ -74,8 +74,8 @@ func NewQCompleter2(model *QAbstractItemModel) *QCompleter {
 
 // NewQCompleter3 constructs a new QCompleter object.
 func NewQCompleter3(completions []string) *QCompleter {
-	// For the C ABI, malloc a C array of raw pointers
-	completions_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(completions))))
+	// For the C ABI, malloc a C array of structs
+	completions_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(completions))))
 	defer C.free(unsafe.Pointer(completions_CArray))
 	for i := range completions {
 		completions_i_ms := C.struct_miqt_string{}
@@ -104,8 +104,8 @@ func NewQCompleter5(model *QAbstractItemModel, parent *QObject) *QCompleter {
 
 // NewQCompleter6 constructs a new QCompleter object.
 func NewQCompleter6(completions []string, parent *QObject) *QCompleter {
-	// For the C ABI, malloc a C array of raw pointers
-	completions_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(completions))))
+	// For the C ABI, malloc a C array of structs
+	completions_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(completions))))
 	defer C.free(unsafe.Pointer(completions_CArray))
 	for i := range completions {
 		completions_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qcoreapplication.go
+++ b/qt/gen_qcoreapplication.go
@@ -273,8 +273,8 @@ func QCoreApplication_ApplicationPid() int64 {
 }
 
 func QCoreApplication_SetLibraryPaths(libraryPaths []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	libraryPaths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(libraryPaths))))
+	// For the C ABI, malloc a C array of structs
+	libraryPaths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(libraryPaths))))
 	defer C.free(unsafe.Pointer(libraryPaths_CArray))
 	for i := range libraryPaths {
 		libraryPaths_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qdir.go
+++ b/qt/gen_qdir.go
@@ -206,8 +206,8 @@ func QDir_SetSearchPaths(prefix string, searchPaths []string) {
 	prefix_ms.data = C.CString(prefix)
 	prefix_ms.len = C.size_t(len(prefix))
 	defer C.free(unsafe.Pointer(prefix_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	searchPaths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(searchPaths))))
+	// For the C ABI, malloc a C array of structs
+	searchPaths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(searchPaths))))
 	defer C.free(unsafe.Pointer(searchPaths_CArray))
 	for i := range searchPaths {
 		searchPaths_i_ms := C.struct_miqt_string{}
@@ -340,8 +340,8 @@ func (this *QDir) NameFilters() []string {
 }
 
 func (this *QDir) SetNameFilters(nameFilters []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -419,8 +419,8 @@ func (this *QDir) EntryList() []string {
 }
 
 func (this *QDir) EntryListWithNameFilters(nameFilters []string) []string {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -459,8 +459,8 @@ func (this *QDir) EntryInfoList() []QFileInfo {
 }
 
 func (this *QDir) EntryInfoListWithNameFilters(nameFilters []string) []QFileInfo {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -689,8 +689,8 @@ func QDir_TempPath() string {
 }
 
 func QDir_Match(filters []string, fileName string) bool {
-	// For the C ABI, malloc a C array of raw pointers
-	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(filters))))
+	// For the C ABI, malloc a C array of structs
+	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(filters))))
 	defer C.free(unsafe.Pointer(filters_CArray))
 	for i := range filters {
 		filters_i_ms := C.struct_miqt_string{}
@@ -768,8 +768,8 @@ func (this *QDir) EntryList2(filters QDir__Filter, sort QDir__SortFlag) []string
 }
 
 func (this *QDir) EntryList22(nameFilters []string, filters QDir__Filter) []string {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -794,8 +794,8 @@ func (this *QDir) EntryList22(nameFilters []string, filters QDir__Filter) []stri
 }
 
 func (this *QDir) EntryList3(nameFilters []string, filters QDir__Filter, sort QDir__SortFlag) []string {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -848,8 +848,8 @@ func (this *QDir) EntryInfoList2(filters QDir__Filter, sort QDir__SortFlag) []QF
 }
 
 func (this *QDir) EntryInfoList22(nameFilters []string, filters QDir__Filter) []QFileInfo {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -874,8 +874,8 @@ func (this *QDir) EntryInfoList22(nameFilters []string, filters QDir__Filter) []
 }
 
 func (this *QDir) EntryInfoList3(nameFilters []string, filters QDir__Filter, sort QDir__SortFlag) []QFileInfo {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qdiriterator.go
+++ b/qt/gen_qdiriterator.go
@@ -82,8 +82,8 @@ func NewQDirIterator4(path string, nameFilters []string) *QDirIterator {
 	path_ms.data = C.CString(path)
 	path_ms.len = C.size_t(len(path))
 	defer C.free(unsafe.Pointer(path_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -130,8 +130,8 @@ func NewQDirIterator8(path string, nameFilters []string, filters QDir__Filter) *
 	path_ms.data = C.CString(path)
 	path_ms.len = C.size_t(len(path))
 	defer C.free(unsafe.Pointer(path_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -152,8 +152,8 @@ func NewQDirIterator9(path string, nameFilters []string, filters QDir__Filter, f
 	path_ms.data = C.CString(path)
 	path_ms.len = C.size_t(len(path))
 	defer C.free(unsafe.Pointer(path_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qdirmodel.go
+++ b/qt/gen_qdirmodel.go
@@ -53,8 +53,8 @@ func UnsafeNewQDirModel(h unsafe.Pointer) *QDirModel {
 
 // NewQDirModel constructs a new QDirModel object.
 func NewQDirModel(nameFilters []string, filters QDir__Filter, sort QDir__SortFlag) *QDirModel {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -77,8 +77,8 @@ func NewQDirModel2() *QDirModel {
 
 // NewQDirModel3 constructs a new QDirModel object.
 func NewQDirModel3(nameFilters []string, filters QDir__Filter, sort QDir__SortFlag, parent *QObject) *QDirModel {
-	// For the C ABI, malloc a C array of raw pointers
-	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(nameFilters))))
+	// For the C ABI, malloc a C array of structs
+	nameFilters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(nameFilters))))
 	defer C.free(unsafe.Pointer(nameFilters_CArray))
 	for i := range nameFilters {
 		nameFilters_i_ms := C.struct_miqt_string{}
@@ -222,8 +222,8 @@ func (this *QDirModel) IconProvider() *QFileIconProvider {
 }
 
 func (this *QDirModel) SetNameFilters(filters []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(filters))))
+	// For the C ABI, malloc a C array of structs
+	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(filters))))
 	defer C.free(unsafe.Pointer(filters_CArray))
 	for i := range filters {
 		filters_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qfiledialog.go
+++ b/qt/gen_qfiledialog.go
@@ -266,8 +266,8 @@ func (this *QFileDialog) SetNameFilter(filter string) {
 }
 
 func (this *QFileDialog) SetNameFilters(filters []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(filters))))
+	// For the C ABI, malloc a C array of structs
+	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(filters))))
 	defer C.free(unsafe.Pointer(filters_CArray))
 	for i := range filters {
 		filters_i_ms := C.struct_miqt_string{}
@@ -318,8 +318,8 @@ func (this *QFileDialog) SelectedNameFilter() string {
 }
 
 func (this *QFileDialog) SetMimeTypeFilters(filters []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(filters))))
+	// For the C ABI, malloc a C array of structs
+	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(filters))))
 	defer C.free(unsafe.Pointer(filters_CArray))
 	for i := range filters {
 		filters_i_ms := C.struct_miqt_string{}
@@ -467,8 +467,8 @@ func (this *QFileDialog) DefaultSuffix() string {
 }
 
 func (this *QFileDialog) SetHistory(paths []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(paths))))
+	// For the C ABI, malloc a C array of structs
+	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(paths))))
 	defer C.free(unsafe.Pointer(paths_CArray))
 	for i := range paths {
 		paths_i_ms := C.struct_miqt_string{}
@@ -528,8 +528,8 @@ func (this *QFileDialog) LabelText(label QFileDialog__DialogLabel) string {
 }
 
 func (this *QFileDialog) SetSupportedSchemes(schemes []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	schemes_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(schemes))))
+	// For the C ABI, malloc a C array of structs
+	schemes_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(schemes))))
 	defer C.free(unsafe.Pointer(schemes_CArray))
 	for i := range schemes {
 		schemes_i_ms := C.struct_miqt_string{}
@@ -613,8 +613,8 @@ func miqt_exec_callback_QFileDialog_FileSelected(cb C.intptr_t, file C.struct_mi
 }
 
 func (this *QFileDialog) FilesSelected(files []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	files_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(files))))
+	// For the C ABI, malloc a C array of structs
+	files_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(files))))
 	defer C.free(unsafe.Pointer(files_CArray))
 	for i := range files {
 		files_i_ms := C.struct_miqt_string{}
@@ -1243,8 +1243,8 @@ func QFileDialog_GetExistingDirectoryUrl5(parent *QWidget, caption string, dir *
 	caption_ms.data = C.CString(caption)
 	caption_ms.len = C.size_t(len(caption))
 	defer C.free(unsafe.Pointer(caption_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	supportedSchemes_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(supportedSchemes))))
+	// For the C ABI, malloc a C array of structs
+	supportedSchemes_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(supportedSchemes))))
 	defer C.free(unsafe.Pointer(supportedSchemes_CArray))
 	for i := range supportedSchemes {
 		supportedSchemes_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qfileselector.go
+++ b/qt/gen_qfileselector.go
@@ -116,8 +116,8 @@ func (this *QFileSelector) ExtraSelectors() []string {
 }
 
 func (this *QFileSelector) SetExtraSelectors(list []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	list_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(list))))
+	// For the C ABI, malloc a C array of structs
+	list_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(list))))
 	defer C.free(unsafe.Pointer(list_CArray))
 	for i := range list {
 		list_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qfilesystemmodel.go
+++ b/qt/gen_qfilesystemmodel.go
@@ -383,8 +383,8 @@ func (this *QFileSystemModel) NameFilterDisables() bool {
 }
 
 func (this *QFileSystemModel) SetNameFilters(filters []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(filters))))
+	// For the C ABI, malloc a C array of structs
+	filters_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(filters))))
 	defer C.free(unsafe.Pointer(filters_CArray))
 	for i := range filters {
 		filters_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qfilesystemwatcher.go
+++ b/qt/gen_qfilesystemwatcher.go
@@ -51,8 +51,8 @@ func NewQFileSystemWatcher() *QFileSystemWatcher {
 
 // NewQFileSystemWatcher2 constructs a new QFileSystemWatcher object.
 func NewQFileSystemWatcher2(paths []string) *QFileSystemWatcher {
-	// For the C ABI, malloc a C array of raw pointers
-	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(paths))))
+	// For the C ABI, malloc a C array of structs
+	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(paths))))
 	defer C.free(unsafe.Pointer(paths_CArray))
 	for i := range paths {
 		paths_i_ms := C.struct_miqt_string{}
@@ -75,8 +75,8 @@ func NewQFileSystemWatcher3(parent *QObject) *QFileSystemWatcher {
 
 // NewQFileSystemWatcher4 constructs a new QFileSystemWatcher object.
 func NewQFileSystemWatcher4(paths []string, parent *QObject) *QFileSystemWatcher {
-	// For the C ABI, malloc a C array of raw pointers
-	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(paths))))
+	// For the C ABI, malloc a C array of structs
+	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(paths))))
 	defer C.free(unsafe.Pointer(paths_CArray))
 	for i := range paths {
 		paths_i_ms := C.struct_miqt_string{}
@@ -128,8 +128,8 @@ func (this *QFileSystemWatcher) AddPath(file string) bool {
 }
 
 func (this *QFileSystemWatcher) AddPaths(files []string) []string {
-	// For the C ABI, malloc a C array of raw pointers
-	files_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(files))))
+	// For the C ABI, malloc a C array of structs
+	files_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(files))))
 	defer C.free(unsafe.Pointer(files_CArray))
 	for i := range files {
 		files_i_ms := C.struct_miqt_string{}
@@ -162,8 +162,8 @@ func (this *QFileSystemWatcher) RemovePath(file string) bool {
 }
 
 func (this *QFileSystemWatcher) RemovePaths(files []string) []string {
-	// For the C ABI, malloc a C array of raw pointers
-	files_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(files))))
+	// For the C ABI, malloc a C array of structs
+	files_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(files))))
 	defer C.free(unsafe.Pointer(files_CArray))
 	for i := range files {
 		files_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qfont.go
+++ b/qt/gen_qfont.go
@@ -265,8 +265,8 @@ func (this *QFont) Families() []string {
 }
 
 func (this *QFont) SetFamilies(families []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	families_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(families))))
+	// For the C ABI, malloc a C array of structs
+	families_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(families))))
 	defer C.free(unsafe.Pointer(families_CArray))
 	for i := range families {
 		families_i_ms := C.struct_miqt_string{}
@@ -580,8 +580,8 @@ func QFont_InsertSubstitutions(param1 string, param2 []string) {
 	param1_ms.data = C.CString(param1)
 	param1_ms.len = C.size_t(len(param1))
 	defer C.free(unsafe.Pointer(param1_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	param2_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(param2))))
+	// For the C ABI, malloc a C array of structs
+	param2_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(param2))))
 	defer C.free(unsafe.Pointer(param2_CArray))
 	for i := range param2 {
 		param2_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qicon.go
+++ b/qt/gen_qicon.go
@@ -252,8 +252,8 @@ func QIcon_ThemeSearchPaths() []string {
 }
 
 func QIcon_SetThemeSearchPaths(searchpath []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	searchpath_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(searchpath))))
+	// For the C ABI, malloc a C array of structs
+	searchpath_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(searchpath))))
 	defer C.free(unsafe.Pointer(searchpath_CArray))
 	for i := range searchpath {
 		searchpath_i_ms := C.struct_miqt_string{}
@@ -282,8 +282,8 @@ func QIcon_FallbackSearchPaths() []string {
 }
 
 func QIcon_SetFallbackSearchPaths(paths []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(paths))))
+	// For the C ABI, malloc a C array of structs
+	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(paths))))
 	defer C.free(unsafe.Pointer(paths_CArray))
 	for i := range paths {
 		paths_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qinputdialog.go
+++ b/qt/gen_qinputdialog.go
@@ -177,8 +177,8 @@ func (this *QInputDialog) IsComboBoxEditable() bool {
 }
 
 func (this *QInputDialog) SetComboBoxItems(items []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}
@@ -365,8 +365,8 @@ func QInputDialog_GetItem(parent *QWidget, title string, label string, items []s
 	label_ms.data = C.CString(label)
 	label_ms.len = C.size_t(len(label))
 	defer C.free(unsafe.Pointer(label_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}
@@ -789,8 +789,8 @@ func QInputDialog_GetItem5(parent *QWidget, title string, label string, items []
 	label_ms.data = C.CString(label)
 	label_ms.len = C.size_t(len(label))
 	defer C.free(unsafe.Pointer(label_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}
@@ -816,8 +816,8 @@ func QInputDialog_GetItem6(parent *QWidget, title string, label string, items []
 	label_ms.data = C.CString(label)
 	label_ms.len = C.size_t(len(label))
 	defer C.free(unsafe.Pointer(label_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}
@@ -843,8 +843,8 @@ func QInputDialog_GetItem7(parent *QWidget, title string, label string, items []
 	label_ms.data = C.CString(label)
 	label_ms.len = C.size_t(len(label))
 	defer C.free(unsafe.Pointer(label_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}
@@ -870,8 +870,8 @@ func QInputDialog_GetItem8(parent *QWidget, title string, label string, items []
 	label_ms.data = C.CString(label)
 	label_ms.len = C.size_t(len(label))
 	defer C.free(unsafe.Pointer(label_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}
@@ -897,8 +897,8 @@ func QInputDialog_GetItem9(parent *QWidget, title string, label string, items []
 	label_ms.data = C.CString(label)
 	label_ms.len = C.size_t(len(label))
 	defer C.free(unsafe.Pointer(label_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(items))))
+	// For the C ABI, malloc a C array of structs
+	items_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(items))))
 	defer C.free(unsafe.Pointer(items_CArray))
 	for i := range items {
 		items_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qjsonarray.go
+++ b/qt/gen_qjsonarray.go
@@ -59,8 +59,8 @@ func (this *QJsonArray) OperatorAssign(other *QJsonArray) {
 }
 
 func QJsonArray_FromStringList(list []string) *QJsonArray {
-	// For the C ABI, malloc a C array of raw pointers
-	list_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(list))))
+	// For the C ABI, malloc a C array of structs
+	list_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(list))))
 	defer C.free(unsafe.Pointer(list_CArray))
 	for i := range list {
 		list_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qlistwidget.go
+++ b/qt/gen_qlistwidget.go
@@ -459,8 +459,8 @@ func (this *QListWidget) InsertItem2(row int, label string) {
 }
 
 func (this *QListWidget) InsertItems(row int, labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}
@@ -487,8 +487,8 @@ func (this *QListWidget) AddItemWithItem(item *QListWidgetItem) {
 }
 
 func (this *QListWidget) AddItems(labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qlocale.go
+++ b/qt/gen_qlocale.go
@@ -1751,8 +1751,8 @@ func (this *QLocale) QuoteString(str string) string {
 }
 
 func (this *QLocale) CreateSeparatedList(strl []string) string {
-	// For the C ABI, malloc a C array of raw pointers
-	strl_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strl))))
+	// For the C ABI, malloc a C array of structs
+	strl_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strl))))
 	defer C.free(unsafe.Pointer(strl_CArray))
 	for i := range strl {
 		strl_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qprocess.go
+++ b/qt/gen_qprocess.go
@@ -311,8 +311,8 @@ func (this *QProcess) Start(program string, arguments []string) {
 	program_ms.data = C.CString(program)
 	program_ms.len = C.size_t(len(program))
 	defer C.free(unsafe.Pointer(program_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -376,8 +376,8 @@ func (this *QProcess) Arguments() []string {
 }
 
 func (this *QProcess) SetArguments(arguments []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -475,8 +475,8 @@ func (this *QProcess) SetWorkingDirectory(dir string) {
 }
 
 func (this *QProcess) SetEnvironment(environment []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	environment_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(environment))))
+	// For the C ABI, malloc a C array of structs
+	environment_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(environment))))
 	defer C.free(unsafe.Pointer(environment_CArray))
 	for i := range environment {
 		environment_i_ms := C.struct_miqt_string{}
@@ -602,8 +602,8 @@ func QProcess_Execute(program string, arguments []string) int {
 	program_ms.data = C.CString(program)
 	program_ms.len = C.size_t(len(program))
 	defer C.free(unsafe.Pointer(program_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -630,8 +630,8 @@ func QProcess_StartDetached2(program string, arguments []string, workingDirector
 	program_ms.data = C.CString(program)
 	program_ms.len = C.size_t(len(program))
 	defer C.free(unsafe.Pointer(program_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -654,8 +654,8 @@ func QProcess_StartDetached3(program string, arguments []string) bool {
 	program_ms.data = C.CString(program)
 	program_ms.len = C.size_t(len(program))
 	defer C.free(unsafe.Pointer(program_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -837,8 +837,8 @@ func (this *QProcess) Start3(program string, arguments []string, mode QIODevice_
 	program_ms.data = C.CString(program)
 	program_ms.len = C.size_t(len(program))
 	defer C.free(unsafe.Pointer(program_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}
@@ -909,8 +909,8 @@ func QProcess_StartDetached4(program string, arguments []string, workingDirector
 	program_ms.data = C.CString(program)
 	program_ms.len = C.size_t(len(program))
 	defer C.free(unsafe.Pointer(program_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(arguments))))
+	// For the C ABI, malloc a C array of structs
+	arguments_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(arguments))))
 	defer C.free(unsafe.Pointer(arguments_CArray))
 	for i := range arguments {
 		arguments_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qsessionmanager.go
+++ b/qt/gen_qsessionmanager.go
@@ -119,8 +119,8 @@ func (this *QSessionManager) RestartHint() QSessionManager__RestartHint {
 }
 
 func (this *QSessionManager) SetRestartCommand(restartCommand []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	restartCommand_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(restartCommand))))
+	// For the C ABI, malloc a C array of structs
+	restartCommand_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(restartCommand))))
 	defer C.free(unsafe.Pointer(restartCommand_CArray))
 	for i := range restartCommand {
 		restartCommand_i_ms := C.struct_miqt_string{}
@@ -149,8 +149,8 @@ func (this *QSessionManager) RestartCommand() []string {
 }
 
 func (this *QSessionManager) SetDiscardCommand(discardCommand []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	discardCommand_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(discardCommand))))
+	// For the C ABI, malloc a C array of structs
+	discardCommand_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(discardCommand))))
 	defer C.free(unsafe.Pointer(discardCommand_CArray))
 	for i := range discardCommand {
 		discardCommand_i_ms := C.struct_miqt_string{}
@@ -195,8 +195,8 @@ func (this *QSessionManager) SetManagerProperty2(name string, value []string) {
 	name_ms.data = C.CString(name)
 	name_ms.len = C.size_t(len(name))
 	defer C.free(unsafe.Pointer(name_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	value_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(value))))
+	// For the C ABI, malloc a C array of structs
+	value_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(value))))
 	defer C.free(unsafe.Pointer(value_CArray))
 	for i := range value {
 		value_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qstandarditemmodel.go
+++ b/qt/gen_qstandarditemmodel.go
@@ -807,8 +807,8 @@ func (this *QStandardItemModel) SetVerticalHeaderItem(row int, item *QStandardIt
 }
 
 func (this *QStandardItemModel) SetHorizontalHeaderLabels(labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}
@@ -823,8 +823,8 @@ func (this *QStandardItemModel) SetHorizontalHeaderLabels(labels []string) {
 }
 
 func (this *QStandardItemModel) SetVerticalHeaderLabels(labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qstandardpaths.go
+++ b/qt/gen_qstandardpaths.go
@@ -188,8 +188,8 @@ func QStandardPaths_FindExecutable2(executableName string, paths []string) strin
 	executableName_ms.data = C.CString(executableName)
 	executableName_ms.len = C.size_t(len(executableName))
 	defer C.free(unsafe.Pointer(executableName_ms.data))
-	// For the C ABI, malloc a C array of raw pointers
-	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(paths))))
+	// For the C ABI, malloc a C array of structs
+	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(paths))))
 	defer C.free(unsafe.Pointer(paths_CArray))
 	for i := range paths {
 		paths_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qstringlistmodel.go
+++ b/qt/gen_qstringlistmodel.go
@@ -51,8 +51,8 @@ func NewQStringListModel() *QStringListModel {
 
 // NewQStringListModel2 constructs a new QStringListModel object.
 func NewQStringListModel2(strings []string) *QStringListModel {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -75,8 +75,8 @@ func NewQStringListModel3(parent *QObject) *QStringListModel {
 
 // NewQStringListModel4 constructs a new QStringListModel object.
 func NewQStringListModel4(strings []string, parent *QObject) *QStringListModel {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -176,8 +176,8 @@ func (this *QStringListModel) StringList() []string {
 }
 
 func (this *QStringListModel) SetStringList(strings []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qtablewidget.go
+++ b/qt/gen_qtablewidget.go
@@ -570,8 +570,8 @@ func (this *QTableWidget) TakeHorizontalHeaderItem(column int) *QTableWidgetItem
 }
 
 func (this *QTableWidget) SetVerticalHeaderLabels(labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}
@@ -586,8 +586,8 @@ func (this *QTableWidget) SetVerticalHeaderLabels(labels []string) {
 }
 
 func (this *QTableWidget) SetHorizontalHeaderLabels(labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qtextbrowser.go
+++ b/qt/gen_qtextbrowser.go
@@ -110,8 +110,8 @@ func (this *QTextBrowser) SearchPaths() []string {
 }
 
 func (this *QTextBrowser) SetSearchPaths(paths []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(paths))))
+	// For the C ABI, malloc a C array of structs
+	paths_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(paths))))
 	defer C.free(unsafe.Pointer(paths_CArray))
 	for i := range paths {
 		paths_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qtextformat.go
+++ b/qt/gen_qtextformat.go
@@ -727,8 +727,8 @@ func (this *QTextCharFormat) FontFamily() string {
 }
 
 func (this *QTextCharFormat) SetFontFamilies(families []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	families_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(families))))
+	// For the C ABI, malloc a C array of structs
+	families_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(families))))
 	defer C.free(unsafe.Pointer(families_CArray))
 	for i := range families {
 		families_i_ms := C.struct_miqt_string{}
@@ -984,8 +984,8 @@ func (this *QTextCharFormat) AnchorName() string {
 }
 
 func (this *QTextCharFormat) SetAnchorNames(names []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(names))))
+	// For the C ABI, malloc a C array of structs
+	names_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(names))))
 	defer C.free(unsafe.Pointer(names_CArray))
 	for i := range names {
 		names_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qtreewidget.go
+++ b/qt/gen_qtreewidget.go
@@ -66,8 +66,8 @@ func NewQTreeWidgetItem() *QTreeWidgetItem {
 
 // NewQTreeWidgetItem2 constructs a new QTreeWidgetItem object.
 func NewQTreeWidgetItem2(strings []string) *QTreeWidgetItem {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -90,8 +90,8 @@ func NewQTreeWidgetItem3(treeview *QTreeWidget) *QTreeWidgetItem {
 
 // NewQTreeWidgetItem4 constructs a new QTreeWidgetItem object.
 func NewQTreeWidgetItem4(treeview *QTreeWidget, strings []string) *QTreeWidgetItem {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -120,8 +120,8 @@ func NewQTreeWidgetItem6(parent *QTreeWidgetItem) *QTreeWidgetItem {
 
 // NewQTreeWidgetItem7 constructs a new QTreeWidgetItem object.
 func NewQTreeWidgetItem7(parent *QTreeWidgetItem, strings []string) *QTreeWidgetItem {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -156,8 +156,8 @@ func NewQTreeWidgetItem10(typeVal int) *QTreeWidgetItem {
 
 // NewQTreeWidgetItem11 constructs a new QTreeWidgetItem object.
 func NewQTreeWidgetItem11(strings []string, typeVal int) *QTreeWidgetItem {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -180,8 +180,8 @@ func NewQTreeWidgetItem12(treeview *QTreeWidget, typeVal int) *QTreeWidgetItem {
 
 // NewQTreeWidgetItem13 constructs a new QTreeWidgetItem object.
 func NewQTreeWidgetItem13(treeview *QTreeWidget, strings []string, typeVal int) *QTreeWidgetItem {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -210,8 +210,8 @@ func NewQTreeWidgetItem15(parent *QTreeWidgetItem, typeVal int) *QTreeWidgetItem
 
 // NewQTreeWidgetItem16 constructs a new QTreeWidgetItem object.
 func NewQTreeWidgetItem16(parent *QTreeWidgetItem, strings []string, typeVal int) *QTreeWidgetItem {
-	// For the C ABI, malloc a C array of raw pointers
-	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(strings))))
+	// For the C ABI, malloc a C array of structs
+	strings_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(strings))))
 	defer C.free(unsafe.Pointer(strings_CArray))
 	for i := range strings {
 		strings_i_ms := C.struct_miqt_string{}
@@ -708,8 +708,8 @@ func (this *QTreeWidget) SetHeaderItem(item *QTreeWidgetItem) {
 }
 
 func (this *QTreeWidget) SetHeaderLabels(labels []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(labels))))
+	// For the C ABI, malloc a C array of structs
+	labels_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(labels))))
 	defer C.free(unsafe.Pointer(labels_CArray))
 	for i := range labels {
 		labels_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qurl.go
+++ b/qt/gen_qurl.go
@@ -532,8 +532,8 @@ func QUrl_ToStringList(uris []QUrl) []string {
 }
 
 func QUrl_FromStringList(uris []string) []QUrl {
-	// For the C ABI, malloc a C array of raw pointers
-	uris_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(uris))))
+	// For the C ABI, malloc a C array of structs
+	uris_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(uris))))
 	defer C.free(unsafe.Pointer(uris_CArray))
 	for i := range uris {
 		uris_i_ms := C.struct_miqt_string{}
@@ -558,8 +558,8 @@ func QUrl_FromStringList(uris []string) []QUrl {
 }
 
 func QUrl_SetIdnWhitelist(idnWhitelist []string) {
-	// For the C ABI, malloc a C array of raw pointers
-	idnWhitelist_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(idnWhitelist))))
+	// For the C ABI, malloc a C array of structs
+	idnWhitelist_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(idnWhitelist))))
 	defer C.free(unsafe.Pointer(idnWhitelist_CArray))
 	for i := range idnWhitelist {
 		idnWhitelist_i_ms := C.struct_miqt_string{}
@@ -776,8 +776,8 @@ func QUrl_ToPercentEncoding3(param1 string, exclude []byte, include []byte) []by
 }
 
 func QUrl_FromStringList2(uris []string, mode QUrl__ParsingMode) []QUrl {
-	// For the C ABI, malloc a C array of raw pointers
-	uris_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(uris))))
+	// For the C ABI, malloc a C array of structs
+	uris_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(uris))))
 	defer C.free(unsafe.Pointer(uris_CArray))
 	for i := range uris {
 		uris_i_ms := C.struct_miqt_string{}

--- a/qt/gen_qvariant.go
+++ b/qt/gen_qvariant.go
@@ -222,8 +222,8 @@ func NewQVariant17(stringVal string) *QVariant {
 
 // NewQVariant18 constructs a new QVariant object.
 func NewQVariant18(stringlist []string) *QVariant {
-	// For the C ABI, malloc a C array of raw pointers
-	stringlist_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(8 * len(stringlist))))
+	// For the C ABI, malloc a C array of structs
+	stringlist_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(stringlist))))
 	defer C.free(unsafe.Pointer(stringlist_CArray))
 	for i := range stringlist {
 		stringlist_i_ms := C.struct_miqt_string{}


### PR DESCRIPTION
Fixes: #48 

This fixes a regression in 434c45273a5b8e885ae88b943617e21075e5a5b8 from #47 earlier today, with passing arrays of QString/QByteArray. An insufficient malloc size was calculated assuming that the contents were always going to be pointers.

Fix the issue and add safeguards in CI to detect it sooner next time.