### PR TITLE
Add Linux ARM64 support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These bindings were newly started in August 2024. The bindings are complete for 
 |OS|Arch|Linkage|Status
 |---|---|---|---
 |Linux|x86_64|Static or Dynamic (.so)|✅ Works
+|Linux|ARM64|Static or Dynamic (.so)|✅ Works
 |Windows|x86_64|Static or Dynamic (.dll)|✅ Works
 |Android|ARM64|Dynamic (bundled in .apk package)|✅ Works
 |macOS|x86_64|Static or Dynamic (.dylib)|✅ Works


### PR DESCRIPTION
I have tested this with a Debian Linux ARM64 system. Both compilation and execution worked well. This did however fail on Asahi Linux but I believe that is because of an issue with Asahi.