### PR TITLE
Fix wrong package name on printsupport cflags

### DIFF
--- a/qt/printsupport/cflags.go
+++ b/qt/printsupport/cflags.go
@@ -1,4 +1,4 @@
-package qprintsupport
+package printsupport
 
 /*
 #cgo CFLAGS: -fPIC

--- a/qt6/printsupport/cflags.go
+++ b/qt6/printsupport/cflags.go
@@ -1,4 +1,4 @@
-package qprintsupport
+package printsupport
 
 /*
 #cgo CFLAGS: -fPIC


### PR DESCRIPTION
Both [qt\printsupport\cflags.go](https://github.com/mappu/miqt/blob/master/qt/printsupport/cflags.go) and [qt6\printsupport\cflags.go](https://github.com/mappu/miqt/blob/master/qt6/printsupport/cflags.go) have `qprintsupport` as package name instead of `printsupport`. This PR fixes that.