### PR TITLE
Support building on 32-bit platforms

### DIFF
--- a/cmd/genbindings/main.go
+++ b/cmd/genbindings/main.go
@@ -222,7 +222,7 @@ func generate(packageName string, srcDirs []string, allowHeaderFn func(string) b
 			counter++
 		}
 
-		goSrc, err := emitGo(parsed, filepath.Base(parsed.Filename), packageName)
+		goSrc, go64Src, err := emitGo(parsed, filepath.Base(parsed.Filename), packageName)
 		if err != nil {
 			panic(err)
 		}
@@ -230,6 +230,13 @@ func generate(packageName string, srcDirs []string, allowHeaderFn func(string) b
 		err = os.WriteFile(outputName+".go", []byte(goSrc), 0644)
 		if err != nil {
 			panic(err)
+		}
+
+		if len(go64Src) > 0 {
+			err = os.WriteFile(outputName+"_64bit.go", []byte(go64Src), 0644)
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		bindingCppSrc, err := emitBindingCpp(parsed, filepath.Base(parsed.Filename))

--- a/docker/win32-cross-go1.23-qt5.15-dynamic.Dockerfile
+++ b/docker/win32-cross-go1.23-qt5.15-dynamic.Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.23-bookworm
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -qyy gnupg2 ca-certificates && \
+    apt-get clean
+
+RUN DEBIAN_FRONTEND=noninteractive \
+    echo "deb https://pkg.mxe.cc/repos/apt buster main" >/etc/apt/sources.list.d/mxeapt.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9 && \
+    apt-get update && \
+    apt-get install -qyy mxe-i686-w64-mingw32.shared-qt5 && \
+    apt-get clean
+
+ENV PATH=/usr/lib/mxe/usr/bin:$PATH
+
+ENV CXX=i686-w64-mingw32.shared-g++
+ENV CC=i686-w64-mingw32.shared-gcc
+ENV PKG_CONFIG=i686-w64-mingw32.shared-pkg-config
+ENV GOOS=windows
+ENV GOARCH=386
+ENV CGO_ENABLED=1
+ENV GOFLAGS=-buildvcs=false

--- a/docker/win32-cross-go1.23-qt5.15-static.Dockerfile
+++ b/docker/win32-cross-go1.23-qt5.15-static.Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.23-bookworm
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -qyy gnupg2 ca-certificates && \
+    apt-get clean
+    
+RUN DEBIAN_FRONTEND=noninteractive \
+    echo "deb https://pkg.mxe.cc/repos/apt buster main" >/etc/apt/sources.list.d/mxeapt.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9 && \
+    apt-get update && \
+    apt-get install -qyy mxe-i686-w64-mingw32.static-qt5 && \
+    apt-get clean
+
+ENV PATH=/usr/lib/mxe/usr/bin:$PATH
+
+ENV CXX=i686-w64-mingw32.static-g++
+ENV CC=i686-w64-mingw32.static-gcc
+ENV PKG_CONFIG=i686-w64-mingw32.static-pkg-config
+ENV GOOS=windows
+ENV GOARCH=386
+ENV CGO_ENABLED=1
+ENV GOFLAGS=-buildvcs=false

--- a/qt-restricted-extras/qscintilla/gen_qsciscintillabase.go
+++ b/qt-restricted-extras/qscintilla/gen_qsciscintillabase.go
@@ -845,7 +845,6 @@ const (
 	QsciScintillaBase__SC_MARKNUM_FOLDERSUB                          QsciScintillaBase__ = 29
 	QsciScintillaBase__SC_MARKNUM_FOLDER                             QsciScintillaBase__ = 30
 	QsciScintillaBase__SC_MARKNUM_FOLDEROPEN                         QsciScintillaBase__ = 31
-	QsciScintillaBase__SC_MASK_FOLDERS                               QsciScintillaBase__ = 4261412864
 	QsciScintillaBase__SC_MARGIN_SYMBOL                              QsciScintillaBase__ = 0
 	QsciScintillaBase__SC_MARGIN_NUMBER                              QsciScintillaBase__ = 1
 	QsciScintillaBase__SC_MARGIN_BACK                                QsciScintillaBase__ = 2

--- a/qt-restricted-extras/qscintilla/gen_qsciscintillabase_64bit.go
+++ b/qt-restricted-extras/qscintilla/gen_qsciscintillabase_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qscintilla
+
+const QsciScintillaBase__SC_MASK_FOLDERS QsciScintillaBase__ = 4261412864
+

--- a/qt-restricted-extras/qscintilla6/gen_qsciscintillabase.go
+++ b/qt-restricted-extras/qscintilla6/gen_qsciscintillabase.go
@@ -845,7 +845,6 @@ const (
 	QsciScintillaBase__SC_MARKNUM_FOLDERSUB                          QsciScintillaBase__ = 29
 	QsciScintillaBase__SC_MARKNUM_FOLDER                             QsciScintillaBase__ = 30
 	QsciScintillaBase__SC_MARKNUM_FOLDEROPEN                         QsciScintillaBase__ = 31
-	QsciScintillaBase__SC_MASK_FOLDERS                               QsciScintillaBase__ = 4261412864
 	QsciScintillaBase__SC_MARGIN_SYMBOL                              QsciScintillaBase__ = 0
 	QsciScintillaBase__SC_MARGIN_NUMBER                              QsciScintillaBase__ = 1
 	QsciScintillaBase__SC_MARGIN_BACK                                QsciScintillaBase__ = 2

--- a/qt-restricted-extras/qscintilla6/gen_qsciscintillabase_64bit.go
+++ b/qt-restricted-extras/qscintilla6/gen_qsciscintillabase_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qscintilla6
+
+const QsciScintillaBase__SC_MASK_FOLDERS QsciScintillaBase__ = 4261412864
+

--- a/qt/cflags_windowsqtstatic.go
+++ b/qt/cflags_windowsqtstatic.go
@@ -12,6 +12,7 @@ package qt
 
 /*
 #cgo windowsqtstatic CXXFLAGS: -DMIQT_WINDOWSQTSTATIC
-#cgo LDFLAGS: -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme
+#cgo amd64 LDFLAGS: -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme
+#cgo 386 LDFLAGS: -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme
 */
 import "C"

--- a/qt/gen_qaccessible.go
+++ b/qt/gen_qaccessible.go
@@ -185,11 +185,10 @@ const (
 type QAccessible__RelationFlag int
 
 const (
-	QAccessible__Label        QAccessible__RelationFlag = 1
-	QAccessible__Labelled     QAccessible__RelationFlag = 2
-	QAccessible__Controller   QAccessible__RelationFlag = 4
-	QAccessible__Controlled   QAccessible__RelationFlag = 8
-	QAccessible__AllRelations QAccessible__RelationFlag = 4294967295
+	QAccessible__Label      QAccessible__RelationFlag = 1
+	QAccessible__Labelled   QAccessible__RelationFlag = 2
+	QAccessible__Controller QAccessible__RelationFlag = 4
+	QAccessible__Controlled QAccessible__RelationFlag = 8
 )
 
 type QAccessible__InterfaceType int

--- a/qt/gen_qaccessible_64bit.go
+++ b/qt/gen_qaccessible_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QAccessible__AllRelations QAccessible__RelationFlag = 4294967295
+

--- a/qt/gen_qgraphicsitem.go
+++ b/qt/gen_qgraphicsitem.go
@@ -103,10 +103,6 @@ const (
 
 type QGraphicsItem__Extension int
 
-const (
-	QGraphicsItem__UserExtension QGraphicsItem__Extension = 2147483648
-)
-
 type QGraphicsPathItem__ int
 
 const (

--- a/qt/gen_qgraphicsitem_64bit.go
+++ b/qt/gen_qgraphicsitem_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QGraphicsItem__UserExtension QGraphicsItem__Extension = 2147483648
+

--- a/qt/gen_qnamespace.go
+++ b/qt/gen_qnamespace.go
@@ -41,14 +41,13 @@ const (
 type KeyboardModifier int
 
 const (
-	NoModifier           KeyboardModifier = 0
-	ShiftModifier        KeyboardModifier = 33554432
-	ControlModifier      KeyboardModifier = 67108864
-	AltModifier          KeyboardModifier = 134217728
-	MetaModifier         KeyboardModifier = 268435456
-	KeypadModifier       KeyboardModifier = 536870912
-	GroupSwitchModifier  KeyboardModifier = 1073741824
-	KeyboardModifierMask KeyboardModifier = 4261412864
+	NoModifier          KeyboardModifier = 0
+	ShiftModifier       KeyboardModifier = 33554432
+	ControlModifier     KeyboardModifier = 67108864
+	AltModifier         KeyboardModifier = 134217728
+	MetaModifier        KeyboardModifier = 268435456
+	KeypadModifier      KeyboardModifier = 536870912
+	GroupSwitchModifier KeyboardModifier = 1073741824
 )
 
 type Modifier int
@@ -58,50 +57,48 @@ const (
 	SHIFT         Modifier = 33554432
 	CTRL          Modifier = 67108864
 	ALT           Modifier = 134217728
-	MODIFIER_MASK Modifier = 4261412864
 	UNICODE_ACCEL Modifier = 0
 )
 
 type MouseButton int
 
 const (
-	NoButton        MouseButton = 0
-	LeftButton      MouseButton = 1
-	RightButton     MouseButton = 2
-	MiddleButton    MouseButton = 4
-	MidButton       MouseButton = 4
-	BackButton      MouseButton = 8
-	XButton1        MouseButton = 8
-	ExtraButton1    MouseButton = 8
-	ForwardButton   MouseButton = 16
-	XButton2        MouseButton = 16
-	ExtraButton2    MouseButton = 16
-	TaskButton      MouseButton = 32
-	ExtraButton3    MouseButton = 32
-	ExtraButton4    MouseButton = 64
-	ExtraButton5    MouseButton = 128
-	ExtraButton6    MouseButton = 256
-	ExtraButton7    MouseButton = 512
-	ExtraButton8    MouseButton = 1024
-	ExtraButton9    MouseButton = 2048
-	ExtraButton10   MouseButton = 4096
-	ExtraButton11   MouseButton = 8192
-	ExtraButton12   MouseButton = 16384
-	ExtraButton13   MouseButton = 32768
-	ExtraButton14   MouseButton = 65536
-	ExtraButton15   MouseButton = 131072
-	ExtraButton16   MouseButton = 262144
-	ExtraButton17   MouseButton = 524288
-	ExtraButton18   MouseButton = 1048576
-	ExtraButton19   MouseButton = 2097152
-	ExtraButton20   MouseButton = 4194304
-	ExtraButton21   MouseButton = 8388608
-	ExtraButton22   MouseButton = 16777216
-	ExtraButton23   MouseButton = 33554432
-	ExtraButton24   MouseButton = 67108864
-	AllButtons      MouseButton = 134217727
-	MaxMouseButton  MouseButton = 67108864
-	MouseButtonMask MouseButton = 4294967295
+	NoButton       MouseButton = 0
+	LeftButton     MouseButton = 1
+	RightButton    MouseButton = 2
+	MiddleButton   MouseButton = 4
+	MidButton      MouseButton = 4
+	BackButton     MouseButton = 8
+	XButton1       MouseButton = 8
+	ExtraButton1   MouseButton = 8
+	ForwardButton  MouseButton = 16
+	XButton2       MouseButton = 16
+	ExtraButton2   MouseButton = 16
+	TaskButton     MouseButton = 32
+	ExtraButton3   MouseButton = 32
+	ExtraButton4   MouseButton = 64
+	ExtraButton5   MouseButton = 128
+	ExtraButton6   MouseButton = 256
+	ExtraButton7   MouseButton = 512
+	ExtraButton8   MouseButton = 1024
+	ExtraButton9   MouseButton = 2048
+	ExtraButton10  MouseButton = 4096
+	ExtraButton11  MouseButton = 8192
+	ExtraButton12  MouseButton = 16384
+	ExtraButton13  MouseButton = 32768
+	ExtraButton14  MouseButton = 65536
+	ExtraButton15  MouseButton = 131072
+	ExtraButton16  MouseButton = 262144
+	ExtraButton17  MouseButton = 524288
+	ExtraButton18  MouseButton = 1048576
+	ExtraButton19  MouseButton = 2097152
+	ExtraButton20  MouseButton = 4194304
+	ExtraButton21  MouseButton = 8388608
+	ExtraButton22  MouseButton = 16777216
+	ExtraButton23  MouseButton = 33554432
+	ExtraButton24  MouseButton = 67108864
+	AllButtons     MouseButton = 134217727
+	MaxMouseButton MouseButton = 67108864
 )
 
 type Orientation int
@@ -255,7 +252,6 @@ const (
 	MacWindowToolBarButtonHint          WindowType = 268435456
 	BypassGraphicsProxyWidget           WindowType = 536870912
 	NoDropShadowWindowHint              WindowType = 1073741824
-	WindowFullscreenButtonHint          WindowType = 2147483648
 )
 
 type WindowState int
@@ -1305,9 +1301,7 @@ const (
 	ImEnterKeyType           InputMethodQuery = 8192
 	ImAnchorRectangle        InputMethodQuery = 16384
 	ImInputItemClipRectangle InputMethodQuery = 32768
-	ImPlatformData           InputMethodQuery = 2147483648
 	ImQueryInput             InputMethodQuery = 16570
-	ImQueryAll               InputMethodQuery = 4294967295
 )
 
 type InputMethodHint int
@@ -1335,7 +1329,6 @@ const (
 	ImhEmailCharactersOnly    InputMethodHint = 2097152
 	ImhUrlCharactersOnly      InputMethodHint = 4194304
 	ImhLatinOnly              InputMethodHint = 8388608
-	ImhExclusiveInputMask     InputMethodHint = 4294901760
 )
 
 type EnterKeyType int
@@ -1561,7 +1554,6 @@ const (
 	PinchGesture      GestureType = 4
 	SwipeGesture      GestureType = 5
 	CustomGesture     GestureType = 256
-	LastGestureType   GestureType = 4294967295
 )
 
 type GestureFlag int

--- a/qt/gen_qnamespace_64bit.go
+++ b/qt/gen_qnamespace_64bit.go
@@ -1,0 +1,14 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const KeyboardModifierMask KeyboardModifier = 4261412864
+const MODIFIER_MASK Modifier = 4261412864
+const MouseButtonMask MouseButton = 4294967295
+const WindowFullscreenButtonHint WindowType = 2147483648
+const ImPlatformData InputMethodQuery = 2147483648
+const ImQueryAll InputMethodQuery = 4294967295
+const ImhExclusiveInputMask InputMethodHint = 4294901760
+const LastGestureType GestureType = 4294967295
+

--- a/qt/gen_qpaintengine.go
+++ b/qt/gen_qpaintengine.go
@@ -21,7 +21,6 @@ const (
 	QTextItem__Overline    QTextItem__RenderFlag = 16
 	QTextItem__Underline   QTextItem__RenderFlag = 32
 	QTextItem__StrikeOut   QTextItem__RenderFlag = 64
-	QTextItem__Dummy       QTextItem__RenderFlag = 4294967295
 )
 
 type QPaintEngine__PaintEngineFeature int
@@ -46,7 +45,6 @@ const (
 	QPaintEngine__ObjectBoundingModeGradients QPaintEngine__PaintEngineFeature = 65536
 	QPaintEngine__RasterOpModes               QPaintEngine__PaintEngineFeature = 131072
 	QPaintEngine__PaintOutsidePaintEvent      QPaintEngine__PaintEngineFeature = 536870912
-	QPaintEngine__AllFeatures                 QPaintEngine__PaintEngineFeature = 4294967295
 )
 
 type QPaintEngine__DirtyFlag int

--- a/qt/gen_qpaintengine_64bit.go
+++ b/qt/gen_qpaintengine_64bit.go
@@ -1,0 +1,8 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QTextItem__Dummy QTextItem__RenderFlag = 4294967295
+const QPaintEngine__AllFeatures QPaintEngine__PaintEngineFeature = 4294967295
+

--- a/qt/gen_qstyle.go
+++ b/qt/gen_qstyle.go
@@ -156,7 +156,6 @@ const (
 	QStyle__CE_ColumnViewGrip      QStyle__ControlElement = 44
 	QStyle__CE_ItemViewItem        QStyle__ControlElement = 45
 	QStyle__CE_ShapedFrame         QStyle__ControlElement = 46
-	QStyle__CE_CustomBase          QStyle__ControlElement = 4026531840
 )
 
 type QStyle__SubElement int
@@ -222,7 +221,6 @@ const (
 	QStyle__SE_TabBarScrollRightButton    QStyle__SubElement = 55
 	QStyle__SE_TabBarTearIndicatorRight   QStyle__SubElement = 56
 	QStyle__SE_PushButtonBevel            QStyle__SubElement = 57
-	QStyle__SE_CustomBase                 QStyle__SubElement = 4026531840
 )
 
 type QStyle__ComplexControl int
@@ -237,7 +235,6 @@ const (
 	QStyle__CC_Dial        QStyle__ComplexControl = 6
 	QStyle__CC_GroupBox    QStyle__ComplexControl = 7
 	QStyle__CC_MdiControls QStyle__ComplexControl = 8
-	QStyle__CC_CustomBase  QStyle__ComplexControl = 4026531840
 )
 
 type QStyle__SubControl int
@@ -284,8 +281,6 @@ const (
 	QStyle__SC_MdiMinButton              QStyle__SubControl = 1
 	QStyle__SC_MdiNormalButton           QStyle__SubControl = 2
 	QStyle__SC_MdiCloseButton            QStyle__SubControl = 4
-	QStyle__SC_CustomBase                QStyle__SubControl = 4026531840
-	QStyle__SC_All                       QStyle__SubControl = 4294967295
 )
 
 type QStyle__PixelMetric int
@@ -389,7 +384,6 @@ const (
 	QStyle__PM_HeaderDefaultSectionSizeVertical   QStyle__PixelMetric = 93
 	QStyle__PM_TitleBarButtonIconSize             QStyle__PixelMetric = 94
 	QStyle__PM_TitleBarButtonSize                 QStyle__PixelMetric = 95
-	QStyle__PM_CustomBase                         QStyle__PixelMetric = 4026531840
 )
 
 type QStyle__ContentsType int
@@ -418,7 +412,6 @@ const (
 	QStyle__CT_GroupBox      QStyle__ContentsType = 20
 	QStyle__CT_MdiControls   QStyle__ContentsType = 21
 	QStyle__CT_ItemViewItem  QStyle__ContentsType = 22
-	QStyle__CT_CustomBase    QStyle__ContentsType = 4026531840
 )
 
 type QStyle__RequestSoftwareInputPanel int
@@ -550,7 +543,6 @@ const (
 	QStyle__SH_ComboBox_AllowWheelScrolling                   QStyle__StyleHint = 115
 	QStyle__SH_SpinBox_ButtonsInsideFrame                     QStyle__StyleHint = 116
 	QStyle__SH_SpinBox_StepModifier                           QStyle__StyleHint = 117
-	QStyle__SH_CustomBase                                     QStyle__StyleHint = 4026531840
 )
 
 type QStyle__StandardPixmap int
@@ -634,7 +626,6 @@ const (
 	QStyle__SP_DialogRetryButton                QStyle__StandardPixmap = 75
 	QStyle__SP_DialogIgnoreButton               QStyle__StandardPixmap = 76
 	QStyle__SP_RestoreDefaultsButton            QStyle__StandardPixmap = 77
-	QStyle__SP_CustomBase                       QStyle__StandardPixmap = 4026531840
 )
 
 type QStyle struct {

--- a/qt/gen_qstyle_64bit.go
+++ b/qt/gen_qstyle_64bit.go
@@ -1,0 +1,15 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QStyle__CE_CustomBase QStyle__ControlElement = 4026531840
+const QStyle__SE_CustomBase QStyle__SubElement = 4026531840
+const QStyle__CC_CustomBase QStyle__ComplexControl = 4026531840
+const QStyle__SC_CustomBase QStyle__SubControl = 4026531840
+const QStyle__SC_All QStyle__SubControl = 4294967295
+const QStyle__PM_CustomBase QStyle__PixelMetric = 4026531840
+const QStyle__CT_CustomBase QStyle__ContentsType = 4026531840
+const QStyle__SH_CustomBase QStyle__StyleHint = 4026531840
+const QStyle__SP_CustomBase QStyle__StandardPixmap = 4026531840
+

--- a/qt/gen_qtextcodec.go
+++ b/qt/gen_qtextcodec.go
@@ -16,10 +16,9 @@ import (
 type QTextCodec__ConversionFlag int
 
 const (
-	QTextCodec__DefaultConversion    QTextCodec__ConversionFlag = 0
-	QTextCodec__ConvertInvalidToNull QTextCodec__ConversionFlag = 2147483648
-	QTextCodec__IgnoreHeader         QTextCodec__ConversionFlag = 1
-	QTextCodec__FreeFunction         QTextCodec__ConversionFlag = 2
+	QTextCodec__DefaultConversion QTextCodec__ConversionFlag = 0
+	QTextCodec__IgnoreHeader      QTextCodec__ConversionFlag = 1
+	QTextCodec__FreeFunction      QTextCodec__ConversionFlag = 2
 )
 
 type QTextCodec struct {

--- a/qt/gen_qtextcodec_64bit.go
+++ b/qt/gen_qtextcodec_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QTextCodec__ConvertInvalidToNull QTextCodec__ConversionFlag = 2147483648
+

--- a/qt/gen_qtextedit.go
+++ b/qt/gen_qtextedit.go
@@ -28,7 +28,6 @@ type QTextEdit__AutoFormattingFlag int
 const (
 	QTextEdit__AutoNone       QTextEdit__AutoFormattingFlag = 0
 	QTextEdit__AutoBulletList QTextEdit__AutoFormattingFlag = 1
-	QTextEdit__AutoAll        QTextEdit__AutoFormattingFlag = 4294967295
 )
 
 type QTextEdit struct {

--- a/qt/gen_qtextedit_64bit.go
+++ b/qt/gen_qtextedit_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QTextEdit__AutoAll QTextEdit__AutoFormattingFlag = 4294967295
+

--- a/qt/gen_qtextoption.go
+++ b/qt/gen_qtextoption.go
@@ -40,7 +40,6 @@ const (
 	QTextOption__AddSpaceForLineAndParagraphSeparators QTextOption__Flag = 4
 	QTextOption__SuppressColors                        QTextOption__Flag = 8
 	QTextOption__ShowDocumentTerminator                QTextOption__Flag = 16
-	QTextOption__IncludeTrailingSpaces                 QTextOption__Flag = 2147483648
 )
 
 type QTextOption struct {

--- a/qt/gen_qtextoption_64bit.go
+++ b/qt/gen_qtextoption_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QTextOption__IncludeTrailingSpaces QTextOption__Flag = 2147483648
+

--- a/qt/gen_qvariant.go
+++ b/qt/gen_qvariant.go
@@ -77,7 +77,6 @@ const (
 	QVariant__LastGuiType          QVariant__Type = 87
 	QVariant__SizePolicy           QVariant__Type = 121
 	QVariant__UserType             QVariant__Type = 1024
-	QVariant__LastType             QVariant__Type = 4294967295
 )
 
 type QVariant struct {

--- a/qt/gen_qvariant_64bit.go
+++ b/qt/gen_qvariant_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt
+
+const QVariant__LastType QVariant__Type = 4294967295
+

--- a/qt/script/gen_qscriptvalue.go
+++ b/qt/script/gen_qscriptvalue.go
@@ -33,7 +33,6 @@ const (
 	QScriptValue__PropertySetter    QScriptValue__PropertyFlag = 16
 	QScriptValue__QObjectMember     QScriptValue__PropertyFlag = 32
 	QScriptValue__KeepExistingFlags QScriptValue__PropertyFlag = 2048
-	QScriptValue__UserRange         QScriptValue__PropertyFlag = 4278190080
 )
 
 type QScriptValue__SpecialValue int

--- a/qt/script/gen_qscriptvalue_64bit.go
+++ b/qt/script/gen_qscriptvalue_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package script
+
+const QScriptValue__UserRange QScriptValue__PropertyFlag = 4278190080
+

--- a/qt6/gen_qaccessible_base.go
+++ b/qt6/gen_qaccessible_base.go
@@ -184,11 +184,10 @@ const (
 type QAccessible__RelationFlag int
 
 const (
-	QAccessible__Label        QAccessible__RelationFlag = 1
-	QAccessible__Labelled     QAccessible__RelationFlag = 2
-	QAccessible__Controller   QAccessible__RelationFlag = 4
-	QAccessible__Controlled   QAccessible__RelationFlag = 8
-	QAccessible__AllRelations QAccessible__RelationFlag = 4294967295
+	QAccessible__Label      QAccessible__RelationFlag = 1
+	QAccessible__Labelled   QAccessible__RelationFlag = 2
+	QAccessible__Controller QAccessible__RelationFlag = 4
+	QAccessible__Controlled QAccessible__RelationFlag = 8
 )
 
 type QAccessible__InterfaceType int

--- a/qt6/gen_qaccessible_base_64bit.go
+++ b/qt6/gen_qaccessible_base_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QAccessible__AllRelations QAccessible__RelationFlag = 4294967295
+

--- a/qt6/gen_qgraphicsitem.go
+++ b/qt6/gen_qgraphicsitem.go
@@ -102,10 +102,6 @@ const (
 
 type QGraphicsItem__Extension int
 
-const (
-	QGraphicsItem__UserExtension QGraphicsItem__Extension = 2147483648
-)
-
 type QGraphicsPathItem__ int
 
 const (

--- a/qt6/gen_qgraphicsitem_64bit.go
+++ b/qt6/gen_qgraphicsitem_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QGraphicsItem__UserExtension QGraphicsItem__Extension = 2147483648
+

--- a/qt6/gen_qnamespace.go
+++ b/qt6/gen_qnamespace.go
@@ -41,42 +41,41 @@ const (
 type MouseButton int
 
 const (
-	NoButton        MouseButton = 0
-	LeftButton      MouseButton = 1
-	RightButton     MouseButton = 2
-	MiddleButton    MouseButton = 4
-	BackButton      MouseButton = 8
-	XButton1        MouseButton = 8
-	ExtraButton1    MouseButton = 8
-	ForwardButton   MouseButton = 16
-	XButton2        MouseButton = 16
-	ExtraButton2    MouseButton = 16
-	TaskButton      MouseButton = 32
-	ExtraButton3    MouseButton = 32
-	ExtraButton4    MouseButton = 64
-	ExtraButton5    MouseButton = 128
-	ExtraButton6    MouseButton = 256
-	ExtraButton7    MouseButton = 512
-	ExtraButton8    MouseButton = 1024
-	ExtraButton9    MouseButton = 2048
-	ExtraButton10   MouseButton = 4096
-	ExtraButton11   MouseButton = 8192
-	ExtraButton12   MouseButton = 16384
-	ExtraButton13   MouseButton = 32768
-	ExtraButton14   MouseButton = 65536
-	ExtraButton15   MouseButton = 131072
-	ExtraButton16   MouseButton = 262144
-	ExtraButton17   MouseButton = 524288
-	ExtraButton18   MouseButton = 1048576
-	ExtraButton19   MouseButton = 2097152
-	ExtraButton20   MouseButton = 4194304
-	ExtraButton21   MouseButton = 8388608
-	ExtraButton22   MouseButton = 16777216
-	ExtraButton23   MouseButton = 33554432
-	ExtraButton24   MouseButton = 67108864
-	AllButtons      MouseButton = 134217727
-	MaxMouseButton  MouseButton = 67108864
-	MouseButtonMask MouseButton = 4294967295
+	NoButton       MouseButton = 0
+	LeftButton     MouseButton = 1
+	RightButton    MouseButton = 2
+	MiddleButton   MouseButton = 4
+	BackButton     MouseButton = 8
+	XButton1       MouseButton = 8
+	ExtraButton1   MouseButton = 8
+	ForwardButton  MouseButton = 16
+	XButton2       MouseButton = 16
+	ExtraButton2   MouseButton = 16
+	TaskButton     MouseButton = 32
+	ExtraButton3   MouseButton = 32
+	ExtraButton4   MouseButton = 64
+	ExtraButton5   MouseButton = 128
+	ExtraButton6   MouseButton = 256
+	ExtraButton7   MouseButton = 512
+	ExtraButton8   MouseButton = 1024
+	ExtraButton9   MouseButton = 2048
+	ExtraButton10  MouseButton = 4096
+	ExtraButton11  MouseButton = 8192
+	ExtraButton12  MouseButton = 16384
+	ExtraButton13  MouseButton = 32768
+	ExtraButton14  MouseButton = 65536
+	ExtraButton15  MouseButton = 131072
+	ExtraButton16  MouseButton = 262144
+	ExtraButton17  MouseButton = 524288
+	ExtraButton18  MouseButton = 1048576
+	ExtraButton19  MouseButton = 2097152
+	ExtraButton20  MouseButton = 4194304
+	ExtraButton21  MouseButton = 8388608
+	ExtraButton22  MouseButton = 16777216
+	ExtraButton23  MouseButton = 33554432
+	ExtraButton24  MouseButton = 67108864
+	AllButtons     MouseButton = 134217727
+	MaxMouseButton MouseButton = 67108864
 )
 
 type Orientation int
@@ -229,7 +228,6 @@ const (
 	MacWindowToolBarButtonHint          WindowType = 268435456
 	BypassGraphicsProxyWidget           WindowType = 536870912
 	NoDropShadowWindowHint              WindowType = 1073741824
-	WindowFullscreenButtonHint          WindowType = 2147483648
 )
 
 type WindowState int
@@ -911,24 +909,22 @@ const (
 type KeyboardModifier int
 
 const (
-	NoModifier           KeyboardModifier = 0
-	ShiftModifier        KeyboardModifier = 33554432
-	ControlModifier      KeyboardModifier = 67108864
-	AltModifier          KeyboardModifier = 134217728
-	MetaModifier         KeyboardModifier = 268435456
-	KeypadModifier       KeyboardModifier = 536870912
-	GroupSwitchModifier  KeyboardModifier = 1073741824
-	KeyboardModifierMask KeyboardModifier = 4261412864
+	NoModifier          KeyboardModifier = 0
+	ShiftModifier       KeyboardModifier = 33554432
+	ControlModifier     KeyboardModifier = 67108864
+	AltModifier         KeyboardModifier = 134217728
+	MetaModifier        KeyboardModifier = 268435456
+	KeypadModifier      KeyboardModifier = 536870912
+	GroupSwitchModifier KeyboardModifier = 1073741824
 )
 
 type Modifier int
 
 const (
-	META          Modifier = 268435456
-	SHIFT         Modifier = 33554432
-	CTRL          Modifier = 67108864
-	ALT           Modifier = 134217728
-	MODIFIER_MASK Modifier = 4261412864
+	META  Modifier = 268435456
+	SHIFT Modifier = 33554432
+	CTRL  Modifier = 67108864
+	ALT   Modifier = 134217728
 )
 
 type ArrowType int
@@ -1279,9 +1275,7 @@ const (
 	ImAnchorRectangle        InputMethodQuery = 16384
 	ImInputItemClipRectangle InputMethodQuery = 32768
 	ImReadOnly               InputMethodQuery = 65536
-	ImPlatformData           InputMethodQuery = 2147483648
 	ImQueryInput             InputMethodQuery = 16570
-	ImQueryAll               InputMethodQuery = 4294967295
 )
 
 type InputMethodHint int
@@ -1309,7 +1303,6 @@ const (
 	ImhEmailCharactersOnly    InputMethodHint = 2097152
 	ImhUrlCharactersOnly      InputMethodHint = 4194304
 	ImhLatinOnly              InputMethodHint = 8388608
-	ImhExclusiveInputMask     InputMethodHint = 4294901760
 )
 
 type EnterKeyType int
@@ -1533,7 +1526,6 @@ const (
 	PinchGesture      GestureType = 4
 	SwipeGesture      GestureType = 5
 	CustomGesture     GestureType = 256
-	LastGestureType   GestureType = 4294967295
 )
 
 type GestureFlag int

--- a/qt6/gen_qnamespace_64bit.go
+++ b/qt6/gen_qnamespace_64bit.go
@@ -1,0 +1,14 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const MouseButtonMask MouseButton = 4294967295
+const WindowFullscreenButtonHint WindowType = 2147483648
+const KeyboardModifierMask KeyboardModifier = 4261412864
+const MODIFIER_MASK Modifier = 4261412864
+const ImPlatformData InputMethodQuery = 2147483648
+const ImQueryAll InputMethodQuery = 4294967295
+const ImhExclusiveInputMask InputMethodHint = 4294901760
+const LastGestureType GestureType = 4294967295
+

--- a/qt6/gen_qpaintengine.go
+++ b/qt6/gen_qpaintengine.go
@@ -21,7 +21,6 @@ const (
 	QTextItem__Overline    QTextItem__RenderFlag = 16
 	QTextItem__Underline   QTextItem__RenderFlag = 32
 	QTextItem__StrikeOut   QTextItem__RenderFlag = 64
-	QTextItem__Dummy       QTextItem__RenderFlag = 4294967295
 )
 
 type QPaintEngine__PaintEngineFeature int
@@ -46,7 +45,6 @@ const (
 	QPaintEngine__ObjectBoundingModeGradients QPaintEngine__PaintEngineFeature = 65536
 	QPaintEngine__RasterOpModes               QPaintEngine__PaintEngineFeature = 131072
 	QPaintEngine__PaintOutsidePaintEvent      QPaintEngine__PaintEngineFeature = 536870912
-	QPaintEngine__AllFeatures                 QPaintEngine__PaintEngineFeature = 4294967295
 )
 
 type QPaintEngine__DirtyFlag int

--- a/qt6/gen_qpaintengine_64bit.go
+++ b/qt6/gen_qpaintengine_64bit.go
@@ -1,0 +1,8 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QTextItem__Dummy QTextItem__RenderFlag = 4294967295
+const QPaintEngine__AllFeatures QPaintEngine__PaintEngineFeature = 4294967295
+

--- a/qt6/gen_qstyle.go
+++ b/qt6/gen_qstyle.go
@@ -154,7 +154,6 @@ const (
 	QStyle__CE_ColumnViewGrip      QStyle__ControlElement = 44
 	QStyle__CE_ItemViewItem        QStyle__ControlElement = 45
 	QStyle__CE_ShapedFrame         QStyle__ControlElement = 46
-	QStyle__CE_CustomBase          QStyle__ControlElement = 4026531840
 )
 
 type QStyle__SubElement int
@@ -218,7 +217,6 @@ const (
 	QStyle__SE_TabBarScrollRightButton    QStyle__SubElement = 54
 	QStyle__SE_TabBarTearIndicatorRight   QStyle__SubElement = 55
 	QStyle__SE_PushButtonBevel            QStyle__SubElement = 56
-	QStyle__SE_CustomBase                 QStyle__SubElement = 4026531840
 )
 
 type QStyle__ComplexControl int
@@ -233,7 +231,6 @@ const (
 	QStyle__CC_Dial        QStyle__ComplexControl = 6
 	QStyle__CC_GroupBox    QStyle__ComplexControl = 7
 	QStyle__CC_MdiControls QStyle__ComplexControl = 8
-	QStyle__CC_CustomBase  QStyle__ComplexControl = 4026531840
 )
 
 type QStyle__SubControl int
@@ -280,8 +277,6 @@ const (
 	QStyle__SC_MdiMinButton              QStyle__SubControl = 1
 	QStyle__SC_MdiNormalButton           QStyle__SubControl = 2
 	QStyle__SC_MdiCloseButton            QStyle__SubControl = 4
-	QStyle__SC_CustomBase                QStyle__SubControl = 4026531840
-	QStyle__SC_All                       QStyle__SubControl = 4294967295
 )
 
 type QStyle__PixelMetric int
@@ -382,7 +377,6 @@ const (
 	QStyle__PM_TitleBarButtonSize                 QStyle__PixelMetric = 92
 	QStyle__PM_LineEditIconSize                   QStyle__PixelMetric = 93
 	QStyle__PM_LineEditIconMargin                 QStyle__PixelMetric = 94
-	QStyle__PM_CustomBase                         QStyle__PixelMetric = 4026531840
 )
 
 type QStyle__ContentsType int
@@ -411,7 +405,6 @@ const (
 	QStyle__CT_GroupBox      QStyle__ContentsType = 20
 	QStyle__CT_MdiControls   QStyle__ContentsType = 21
 	QStyle__CT_ItemViewItem  QStyle__ContentsType = 22
-	QStyle__CT_CustomBase    QStyle__ContentsType = 4026531840
 )
 
 type QStyle__RequestSoftwareInputPanel int
@@ -544,7 +537,6 @@ const (
 	QStyle__SH_TabBar_AllowWheelScrolling                     QStyle__StyleHint = 117
 	QStyle__SH_Table_AlwaysDrawLeftTopGridLines               QStyle__StyleHint = 118
 	QStyle__SH_SpinBox_SelectOnStep                           QStyle__StyleHint = 119
-	QStyle__SH_CustomBase                                     QStyle__StyleHint = 4026531840
 )
 
 type QStyle__StandardPixmap int
@@ -630,7 +622,6 @@ const (
 	QStyle__SP_RestoreDefaultsButton            QStyle__StandardPixmap = 77
 	QStyle__SP_TabCloseButton                   QStyle__StandardPixmap = 78
 	QStyle__NStandardPixmap                     QStyle__StandardPixmap = 79
-	QStyle__SP_CustomBase                       QStyle__StandardPixmap = 4026531840
 )
 
 type QStyle struct {

--- a/qt6/gen_qstyle_64bit.go
+++ b/qt6/gen_qstyle_64bit.go
@@ -1,0 +1,15 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QStyle__CE_CustomBase QStyle__ControlElement = 4026531840
+const QStyle__SE_CustomBase QStyle__SubElement = 4026531840
+const QStyle__CC_CustomBase QStyle__ComplexControl = 4026531840
+const QStyle__SC_CustomBase QStyle__SubControl = 4026531840
+const QStyle__SC_All QStyle__SubControl = 4294967295
+const QStyle__PM_CustomBase QStyle__PixelMetric = 4026531840
+const QStyle__CT_CustomBase QStyle__ContentsType = 4026531840
+const QStyle__SH_CustomBase QStyle__StyleHint = 4026531840
+const QStyle__SP_CustomBase QStyle__StandardPixmap = 4026531840
+

--- a/qt6/gen_qtextedit.go
+++ b/qt6/gen_qtextedit.go
@@ -28,7 +28,6 @@ type QTextEdit__AutoFormattingFlag int
 const (
 	QTextEdit__AutoNone       QTextEdit__AutoFormattingFlag = 0
 	QTextEdit__AutoBulletList QTextEdit__AutoFormattingFlag = 1
-	QTextEdit__AutoAll        QTextEdit__AutoFormattingFlag = 4294967295
 )
 
 type QTextEdit struct {

--- a/qt6/gen_qtextedit_64bit.go
+++ b/qt6/gen_qtextedit_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QTextEdit__AutoAll QTextEdit__AutoFormattingFlag = 4294967295
+

--- a/qt6/gen_qtextoption.go
+++ b/qt6/gen_qtextoption.go
@@ -40,7 +40,6 @@ const (
 	QTextOption__AddSpaceForLineAndParagraphSeparators QTextOption__Flag = 4
 	QTextOption__SuppressColors                        QTextOption__Flag = 8
 	QTextOption__ShowDocumentTerminator                QTextOption__Flag = 16
-	QTextOption__IncludeTrailingSpaces                 QTextOption__Flag = 2147483648
 )
 
 type QTextOption struct {

--- a/qt6/gen_qtextoption_64bit.go
+++ b/qt6/gen_qtextoption_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QTextOption__IncludeTrailingSpaces QTextOption__Flag = 2147483648
+

--- a/qt6/gen_qvariant.go
+++ b/qt6/gen_qvariant.go
@@ -75,7 +75,6 @@ const (
 	QVariant__LastGuiType          QVariant__Type = 4119
 	QVariant__SizePolicy           QVariant__Type = 8192
 	QVariant__UserType             QVariant__Type = 65536
-	QVariant__LastType             QVariant__Type = 4294967295
 )
 
 type QVariant struct {

--- a/qt6/gen_qvariant_64bit.go
+++ b/qt6/gen_qvariant_64bit.go
@@ -1,0 +1,7 @@
+//go:build !386 && !arm
+// +build !386,!arm
+
+package qt6
+
+const QVariant__LastType QVariant__Type = 4294967295
+


### PR DESCRIPTION
Fixes: #3 

The only thing preventing using Miqt on 32-bit was some large integer constants. Move them to a separate `_64bit.go` file that is blocked on `386` and `arm` GOARCH.

This is not a complete list of 32-bit GOARCH but it's the only common ones. More could be added. There is no builtin build tag for "32-bit".

Add 32-bit Windows docker containers.