### PR TITLE
Add `Makefile` for rebuilding bindings

### DIFF
--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -13,10 +13,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    
-    - name: Linux64 docker build
-      run: docker build -t miqt/genbindings:latest -f docker/genbindings.Dockerfile .
-    
+
     - name: Cache clang ASTs
       uses: actions/cache@v4
       with:
@@ -24,7 +21,7 @@ jobs:
         key: linux64-clang-cache
         
     - name: Rebuild binding source
-      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/genbindings:latest /bin/bash -c 'cd cmd/genbindings && go build && ./genbindings'
+      run: make
     
     - name: Assert no changes
       run: git update-index --really-refresh && git diff-index HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ examples/libraries/restricted-extras-qscintilla/restricted-extras-qscintilla
 # android temporary build files
 android-build
 deployment-settings.json
+
+*.docker-buildstamp
+compile_flags.txt

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ clean:
 	rm -f $(BUILDSTAMPS)
 
 genbindings: $(BUILDSTAMPS)
+	mkdir -p ~/.cache/go-build
 	docker run --user $$(id -u):$$(id -g) -v ~/.cache/go-build:/.cache/go-build -v $$PWD:/src -w /src miqt/genbindings:latest /bin/bash -c 'cd cmd/genbindings && go build && ./genbindings'
 
 .PHONY : all clean genbindings

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+BUILDSTAMPS = docker/genbindings.docker-buildstamp
+
+all: genbindings
+
+docker/genbindings.docker-buildstamp: docker/genbindings.Dockerfile
+	docker build -t miqt/genbindings:latest -f docker/genbindings.Dockerfile .
+	touch $@
+
+clean:
+	docker image rm -f miqt/genbindings:latest
+	rm -f $(BUILDSTAMPS)
+
+genbindings: $(BUILDSTAMPS)
+	docker run --user $$(id -u):$$(id -g) -v ~/.cache/go-build:/.cache/go-build -v $$PWD:/src -w /src miqt/genbindings:latest /bin/bash -c 'cd cmd/genbindings && go build && ./genbindings'
+
+.PHONY : all clean genbindings


### PR DESCRIPTION
Having a makefile is a nice little trick to re-run the binding generation code without having to copy-paste and/or remember the right docker incantations :)