### PR TITLE
Fix Compilation issues/125 on Windows with UCRT64 Environment 

### DIFF
--- a/qt6/gen_qhashfunctions.cpp
+++ b/qt6/gen_qhashfunctions.cpp
@@ -16,7 +16,7 @@ QHashSeed* QHashSeed_new2(size_t d) {
 }
 
 size_t QHashSeed_ToUnsignedLong(const QHashSeed* self) {
-	return self->operator unsigned long();
+	return static_cast<unsigned long>(*self);
 }
 
 QHashSeed* QHashSeed_GlobalSeed() {


### PR DESCRIPTION
This pull request addresses compilation issues encountered when building the mappu/miqt project on Windows using the MSYS2 environment with UCRT64 