### PR TITLE
docs: Add more projects in README, update copyright year

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
-Copyright 2024 mappu
-Copyright 2024 The MIQT developers
+Copyright 2024 - 2025, mappu
+Copyright 2025 - 2025, The MIQT developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in the

--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ You must also meet your Qt license obligations.
 
 ## Made with MIQT
 
+These apps are listed in alphabetical order. Raise an issue or PR to have your app listed here!
+
+- [jqview](https://github.com/rcalixte/jqview), The simplest possible native GUI for inspecting JSON objects with jq
 - [mdoutliner](https://github.com/mappu/miqt/tree/master/examples/mdoutliner), Markdown Outliner sample application
 - [qbolt](https://code.ivysaur.me/qbolt), a graphical database manager for BoltDB
-- Raise an issue or PR to have your app listed here!
+- [qocker-miqt](https://code.ivysaur.me/qocker-miqt), a user-friendly GUI application for managing Docker containers
+- See more users of the [qt5](https://pkg.go.dev/github.com/mappu/miqt/qt?tab=importedby) or [qt6](https://pkg.go.dev/github.com/mappu/miqt/qt6?tab=importedby) packages
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Qt class inherited types are projected as a Go embedded struct. For example, to 
 
 - When a Qt subclass adds a method overload (e.g. `QMenu::addAction(QString)` vs `QWidget::addAction(QAction*)`), the base class version is shadowed and can only be called via `myQMenu.QWidget.AddAction(QAction*)`.
 
+- A MIQT pointer points to a Go struct, not to the raw C++ Qt widget class. Therefore `QTabWidget.CurrentWidget() == MyTab` will never compare equal because `CurrentWidget()` created a new Go struct wrapping the same C++ pointer. You can compare `QTabWidget.CurrentIndex()`, or, you can use: `QTabWidget.CurrentWidget().UnsafePointer() == MyTab.UnsafePointer()`.
+
 The Go runtime migrates goroutines between OS threads, but Qt expects fixed OS threads to be used for each QObject. When you first call `qt.NewQApplication` in MIQT, that will be considered the [Qt main thread](https://doc.qt.io/qt-6/thread-basics.html#gui-thread-and-worker-thread) and will automatically signal the Go runtime to bind to a fixed OS thread using `runtime.LockOSThread()`.
 
 - When accessing Qt objects from inside another goroutine, it's safest to use `(qt6/mainthread).Wait()` to access the Qt objects from Qt's main thread.


### PR DESCRIPTION
Update the miqt list of known projects.

- Thanks @rcalixte for porting jqview. I also ported @xlmnxp's [Qocker](https://github.com/xlmnxp/Qocker) program from Python to Go as a test case.

Update the copyright year 2024->2025 :calendar: 