### PR TITLE
Add mingw-w64-x86_64 Qt 6 docker container, test in CI

### DIFF
--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -100,7 +100,7 @@ jobs:
         key: win64-gocache
     
     - name: Win64 docker build
-      run: docker build -t miqt/win64:latest -f docker/win64-cross-go1.23-qt5.15-static.Dockerfile .
+      run: docker build -t miqt/win64:qt5 -f docker/win64-cross-go1.23-qt5.15-static.Dockerfile .
     
     - name: Win64 bindings compile
-      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/win64:latest /bin/bash -c 'cd qt && go build'
+      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/win64:qt5 /bin/bash -c 'cd qt && go build'

--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -86,6 +86,25 @@ jobs:
     - name: Linux64 bindings compile
       run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/linux64:qt68 /bin/bash -c 'cd qt6 && go build'
     
+  miqt_win32_qt5:
+    runs-on: ubuntu-24.04
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Cache GOCACHE
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/go-build
+        key: win32-gocache
+    
+    - name: Win32 docker build
+      run: docker build -t miqt/win32:qt5 -f docker/win32-cross-go1.23-qt5.15-static.Dockerfile .
+    
+    - name: Win32 bindings compile
+      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/win32:qt5 /bin/bash -c 'cd qt && go build'
+
   miqt_win64_qt5:
     runs-on: ubuntu-24.04
     

--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -123,3 +123,22 @@ jobs:
     
     - name: Win64 bindings compile
       run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/win64:qt5 /bin/bash -c 'cd qt && go build'
+
+  miqt_win64_qt68:
+    runs-on: ubuntu-24.04
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Cache GOCACHE
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/go-build
+        key: win64-gocache
+    
+    - name: Win64 docker build
+      run: docker build -t miqt/win64:qt68 -f docker/win64-cross-go1.23-qt6.8-dynamic.Dockerfile .
+    
+    - name: Win64 bindings compile
+      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src miqt/win64:qt68 /bin/bash -c 'cd qt6 && go build'

--- a/cmd/genbindings/config-allowlist.go
+++ b/cmd/genbindings/config-allowlist.go
@@ -301,6 +301,14 @@ func AllowMethod(className string, mm CppMethod) error {
 		return ErrTooComplex
 	}
 
+	if className == "QHashSeed" && mm.MethodName == "operator unsigned long" {
+		// Not present in Qt 5, is present in Qt 6.4 and 6.8, but in the C++
+		// header file it is written as `operator size_t()`
+		// Clang is early-converting size_t to unsigned long, which is invalid for mingw-w64-x86_64 platforms
+		// A proper fix here would be to avoid evaluating typedefs
+		return ErrTooComplex
+	}
+
 	return nil // OK, allow
 }
 

--- a/docker/win64-cross-go1.23-qt6.8-dynamic.Dockerfile
+++ b/docker/win64-cross-go1.23-qt6.8-dynamic.Dockerfile
@@ -1,0 +1,13 @@
+FROM fedora:41
+
+RUN dnf -y --setopt=install_weak_deps=False install \
+	mingw64-qt6-qtbase.x86_64 \
+	mingw64-gcc.x86_64 \
+	mingw64-gcc-c++.x86_64 \
+	golang.x86_64
+
+ENV CC=x86_64-w64-mingw32-gcc
+ENV CXX=x86_64-w64-mingw32-g++
+ENV PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/sys-root/mingw/lib/pkgconfig/
+ENV GOOS=windows
+ENV CGO_ENABLED=1

--- a/qt6/gen_qhashfunctions.cpp
+++ b/qt6/gen_qhashfunctions.cpp
@@ -18,10 +18,6 @@ QHashSeed* QHashSeed_new2(size_t d) {
 	return new QHashSeed(static_cast<size_t>(d));
 }
 
-size_t QHashSeed_ToUnsignedLong(const QHashSeed* self) {
-	return self->operator unsigned long();
-}
-
 QHashSeed* QHashSeed_GlobalSeed() {
 	return new QHashSeed(QHashSeed::globalSeed());
 }

--- a/qt6/gen_qhashfunctions.go
+++ b/qt6/gen_qhashfunctions.go
@@ -62,10 +62,6 @@ func NewQHashSeed2(d uint64) *QHashSeed {
 	return ret
 }
 
-func (this *QHashSeed) ToUnsignedLong() uint64 {
-	return (uint64)(C.QHashSeed_ToUnsignedLong(this.h))
-}
-
 func QHashSeed_GlobalSeed() *QHashSeed {
 	_goptr := newQHashSeed(C.QHashSeed_GlobalSeed())
 	_goptr.GoGC() // Qt uses pass-by-value semantics for this type. Mimic with finalizer

--- a/qt6/gen_qhashfunctions.h
+++ b/qt6/gen_qhashfunctions.h
@@ -22,7 +22,6 @@ typedef struct QHashSeed QHashSeed;
 
 QHashSeed* QHashSeed_new();
 QHashSeed* QHashSeed_new2(size_t d);
-size_t QHashSeed_ToUnsignedLong(const QHashSeed* self);
 QHashSeed* QHashSeed_GlobalSeed();
 void QHashSeed_SetDeterministicGlobalSeed();
 void QHashSeed_ResetRandomGlobalSeed();


### PR DESCRIPTION
Updates: #74 

Fixes: #125 

1. Add a docker container for Qt 6.8 mingw-w64 (Dynamic linked only, not static linked)
2. Update the Github CI to test not only win64-qt5, but also, win32-qt5 and win64-qt6.8
    - This is expected to reproduce issue #125 
    - Confirmed reproduces the issue on d7c019b2a731f0a95f59e1316900e9fe59ad6f4a : https://github.com/mappu/miqt/actions/runs/12721139515/job/35463713233?pr=131 
3. Block the `QHashSeed::operator unsigned long` function from generation
    - This resolves the issue above