### PR TITLE
Log blocked methods

### DIFF
--- a/cmd/genbindings/main.go
+++ b/cmd/genbindings/main.go
@@ -329,6 +329,8 @@ func generateClangCaches(includeFiles []string, clangBin string, cflags []string
 }
 
 func main() {
+	// data/time flags make logs hard to compare across runs
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 	clang := flag.String("clang", "clang", "Custom path to clang")
 	outDir := flag.String("outdir", "../../", "Output directory for generated gen_** files")
 	extraLibsDir := flag.String("extralibs", "/usr/local/src/", "Base directory to find extra library checkouts")


### PR DESCRIPTION
Blocked methods are the source of many gaps in the binding - in particular, they block qt_metacall/activate/etc that is necessary for implementing meta-object support.

This change makes them visible in logs and also removes log timestamps so that logs from two runs easily can be diffed.