### PR TITLE
Use aqt for genbindings

### DIFF
--- a/cmd/genbindings/config-libraries.go
+++ b/cmd/genbindings/config-libraries.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+const Qt5Root = "/opt/Qt/5.15.2/gcc_64/"
+const Qt6Root = "/opt/Qt/6.2.4/gcc_64/"
+
 func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 
 	AllowAllHeaders := func(string) bool { return true }
@@ -15,9 +18,10 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtCore",
-			"/usr/include/x86_64-linux-gnu/qt5/QtGui",
-			"/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
+			Qt5Root + "QtCore",
+			Qt5Root + "QtCore",
+			Qt5Root + "QtGui",
+			Qt5Root + "QtWidgets",
 		},
 		func(fullpath string) bool {
 			// Block cbor and generate it separately
@@ -37,7 +41,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/cbor",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtCore",
+			Qt5Root + "QtCore",
 		},
 		func(fullpath string) bool {
 			// Only include the same json, xml, cbor files excluded above
@@ -53,7 +57,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/printsupport",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtPrintSupport",
+			Qt5Root + "QtPrintSupport",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -65,7 +69,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/svg",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtSvg",
+			Qt5Root + "QtSvg",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -77,7 +81,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/network",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtNetwork",
+			Qt5Root + "QtNetwork",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -92,8 +96,8 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 			// Theoretically, QtMultimediaWidgets and QtMultimedia are different
 			// packages, but QtMultimedia qcamera.h has a dependency on qvideowidget.
 			// Bind them together since our base /qt/ package is Widgets anyway.
-			"/usr/include/x86_64-linux-gnu/qt5/QtMultimedia",
-			"/usr/include/x86_64-linux-gnu/qt5/QtMultimediaWidgets",
+			Qt5Root + "QtMultimedia",
+			Qt5Root + "QtMultimediaWidgets",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -105,7 +109,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/script",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtScript",
+			Qt5Root + "QtScript",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -119,8 +123,8 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/webkit",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtWebKit",
-			"/usr/include/x86_64-linux-gnu/qt5/QtWebKitWidgets",
+			Qt5Root + "QtWebKit",
+			Qt5Root + "QtWebKitWidgets",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -133,7 +137,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/webchannel",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtWebChannel",
+			Qt5Root + "QtWebChannel",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -146,9 +150,9 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt/webengine",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/QtWebEngine",
-			"/usr/include/x86_64-linux-gnu/qt5/QtWebEngineCore",
-			"/usr/include/x86_64-linux-gnu/qt5/QtWebEngineWidgets",
+			Qt5Root + "QtWebEngine",
+			Qt5Root + "QtWebEngineCore",
+			Qt5Root + "QtWebEngineWidgets",
 		},
 
 		func(fullpath string) bool {
@@ -168,7 +172,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt-restricted-extras/qscintilla",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt5/Qsci",
+			Qt5Root + "Qsci",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -199,9 +203,9 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtCore",
-			"/usr/include/x86_64-linux-gnu/qt6/QtGui",
-			"/usr/include/x86_64-linux-gnu/qt6/QtWidgets",
+			Qt6Root + "QtCore",
+			Qt6Root + "QtGui",
+			Qt6Root + "QtWidgets",
 		},
 		func(fullpath string) bool {
 			// Block cbor and generate it separately
@@ -221,7 +225,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/cbor",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtCore",
+			Qt6Root + "QtCore",
 		},
 		func(fullpath string) bool {
 			// Only include the same json, xml, cbor files excluded above
@@ -238,7 +242,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/printsupport",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtPrintSupport",
+			Qt6Root + "QtPrintSupport",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -251,8 +255,8 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/svg",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtSvg",
-			"/usr/include/x86_64-linux-gnu/qt6/QtSvgWidgets",
+			Qt6Root + "QtSvg",
+			Qt6Root + "QtSvgWidgets",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -265,7 +269,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/network",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtNetwork",
+			Qt6Root + "QtNetwork",
 		},
 		func(fullpath string) bool {
 			fname := filepath.Base(fullpath)
@@ -281,8 +285,8 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/multimedia",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtMultimedia",
-			"/usr/include/x86_64-linux-gnu/qt6/QtMultimediaWidgets",
+			Qt6Root + "QtMultimedia",
+			Qt6Root + "QtMultimediaWidgets",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -295,7 +299,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/spatialaudio",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtSpatialAudio",
+			Qt6Root + "QtSpatialAudio",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -308,7 +312,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/webchannel",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtWebChannel",
+			Qt6Root + "QtWebChannel",
 		},
 		AllowAllHeaders,
 		clangBin,
@@ -321,8 +325,8 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt6/webengine",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/QtWebEngineCore",
-			"/usr/include/x86_64-linux-gnu/qt6/QtWebEngineWidgets",
+			Qt6Root + "QtWebEngineCore",
+			Qt6Root + "QtWebEngineWidgets",
 		},
 		func(fullpath string) bool {
 			baseName := filepath.Base(fullpath)
@@ -342,7 +346,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	generate(
 		"qt-restricted-extras/qscintilla6",
 		[]string{
-			"/usr/include/x86_64-linux-gnu/qt6/Qsci",
+			Qt6Root + "Qsci",
 		},
 		AllowAllHeaders,
 		clangBin,

--- a/cmd/genbindings/config-libraries.go
+++ b/cmd/genbindings/config-libraries.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-const Qt5Root = "/opt/Qt/5.15.2/gcc_64/"
-const Qt6Root = "/opt/Qt/6.2.4/gcc_64/"
+const Qt5Root = "/opt/Qt/5.15.2/gcc_64/include/"
+const Qt6Root = "/opt/Qt/6.2.4/gcc_64/include/"
 
 func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 

--- a/docker/genbindings.Dockerfile
+++ b/docker/genbindings.Dockerfile
@@ -1,19 +1,14 @@
 FROM debian:bookworm
 
+ENV QT6_VERSION=6.2.4
+ENV QT5_VERSION=5.15.2
+
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install --no-install-recommends -qyy \
+        python3 \
+        python3-pip \
+        python3.11-venv \
         golang-go \
-        qtbase5-dev \
-        qtmultimedia5-dev \
-        qtscript5-dev \
-        libqt5svg5-dev \
-        libqt5webkit5-dev \
-        qtwebengine5-dev \
-        qt6-base-dev \
-        qt6-multimedia-dev \
-        qt6-svg-dev \
-        qt6-webengine-dev \
-        libqscintilla2-qt5-dev \
         libqscintilla2-qt6-dev \
         clang \
         git \
@@ -21,23 +16,24 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         pkg-config \
         build-essential && \
     apt-get clean
-    
-RUN mkdir -p /usr/local/src/scintilla && \
-    git clone 'https://github.com/mirror/scintilla.git' /usr/local/src/scintilla && \
-    git -C /usr/local/src/scintilla checkout rel-5-5-2
-    
-RUN \
-    cd /usr/local/src/scintilla/qt/ScintillaEditBase && \
-    qmake && \
-    make && \
-    cd /usr/local/src/scintilla/qt/ScintillaEdit && \
-    python3 WidgetGen.py && \
-    qmake && \
-    make
 
-RUN mkdir -p /usr/local/lib/pkgconfig
+RUN python3 -m venv /opt/virtualenvironment
+ENV PATH="/opt/virtualenvironment/bin:$PATH"
+RUN python3 -m pip install aqtinstall
 
-COPY pkg-config/QScintilla.pc.example /usr/local/lib/pkgconfig/QScintilla.pc
-COPY pkg-config/ScintillaEdit.pc.example /usr/local/lib/pkgconfig/ScintillaEdit.pc
+RUN aqt install-qt linux desktop $QT5_VERSION gcc_64 --outputdir /opt/Qt
+ENV PATH=/opt/Qt/$QT5_VERSION/gcc_64/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/Qt/$QT5_VERSION/gcc_64/lib
+ENV QT_PLUGIN_PATH=/opt/Qt/$QT5_VERSION/gcc_64/plugins
+ENV QTDIR=/opt/Qt/$QT5_VERSION/gcc_64
+ENV PKG_CONFIG_PATH=/opt/Qt/$QT5_VERSION/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH
+
+RUN aqt install-qt linux desktop $QT6_VERSION gcc_64 --outputdir /opt/Qt
+ENV PATH=/opt/Qt/$QT6_VERSION/gcc_64/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/Qt/$QT6_VERSION/gcc_64/lib
+ENV QT_PLUGIN_PATH=/opt/Qt/$QT6_VERSION/gcc_64/plugins
+ENV QTDIR=/opt/Qt/$QT6_VERSION/gcc_64
+ENV PKG_CONFIG_PATH=/opt/Qt/$QT6_VERSION/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH
+
 
 ENV GOFLAGS=-buildvcs=false

--- a/docker/genbindings.Dockerfile
+++ b/docker/genbindings.Dockerfile
@@ -35,5 +35,26 @@ ENV QT_PLUGIN_PATH=/opt/Qt/$QT6_VERSION/gcc_64/plugins
 ENV QTDIR=/opt/Qt/$QT6_VERSION/gcc_64
 ENV PKG_CONFIG_PATH=/opt/Qt/$QT6_VERSION/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH
 
+RUN mkdir -p /usr/local/src/scintilla && \
+    git clone 'https://github.com/mirror/scintilla.git' /usr/local/src/scintilla && \
+    git -C /usr/local/src/scintilla checkout rel-5-5-2
+
+RUN \
+    cd /usr/local/src/scintilla/qt/ScintillaEditBase && \
+    qmake && \
+    make && \
+    cd /usr/local/src/scintilla/qt/ScintillaEdit && \
+    python3 WidgetGen.py && \
+    qmake && \
+    make
+
+RUN mkdir -p /usr/local/lib/pkgconfig
+
+COPY pkg-config/QScintilla.pc.example /opt/Qt/$QT5_VERSION/gcc_64/lib/pkgconfig/QScintilla.pc
+COPY pkg-config/ScintillaEdit.pc.example /opt/Qt/$QT5_VERSION/gcc_64/lib/pkgconfig/ScintillaEdit.pc
+
+COPY pkg-config/QScintilla.pc.example /opt/Qt/$QT6_VERSION/gcc_64/lib/pkgconfig/QScintilla.pc
+COPY pkg-config/ScintillaEdit.pc.example /opt/Qt/$QT6_VERSION/gcc_64/lib/pkgconfig/ScintillaEdit.pc
+
 
 ENV GOFLAGS=-buildvcs=false


### PR DESCRIPTION
This PR starts to switch to using [aqt](https://github.com/miurahr/aqtinstall) to target specific versions of Qt instead of relying on the version the distro provides