### PR TITLE
Qt 6.8.2 compatibility fix for QStringConverterBase

### DIFF
--- a/cmd/genbindings/clang2il.go
+++ b/cmd/genbindings/clang2il.go
@@ -394,6 +394,10 @@ nextMethod:
 			// an existing class instance
 			mm.IsStatic = true
 
+			if !AllowCtor(ret.ClassName, mm) {
+				continue
+			}
+
 			ret.Ctors = append(ret.Ctors, mm)
 
 		case "CXXDestructorDecl":

--- a/cmd/genbindings/config-allowlist.go
+++ b/cmd/genbindings/config-allowlist.go
@@ -323,6 +323,14 @@ func AllowMethod(className string, mm CppMethod) error {
 
 func AllowCtor(className string, mm CppMethod) bool {
 
+	if className == `QStringConverterBase` {
+		// Both the main ctor and the copy constructor were changed from public to protected between 6.8.1 and 6.8.2
+		// @ref https://github.com/qt/qtbase/commit/41679e0b4398c0de38a8107642dc643fe2c3554f
+		// @ref https://github.com/mappu/miqt/issues/168
+		// Block both ctors from generation
+		return false
+	}
+
 	// Default allow
 	return true
 }

--- a/cmd/genbindings/config-allowlist.go
+++ b/cmd/genbindings/config-allowlist.go
@@ -321,6 +321,12 @@ func AllowMethod(className string, mm CppMethod) error {
 	return nil // OK, allow
 }
 
+func AllowCtor(className string, mm CppMethod) bool {
+
+	// Default allow
+	return true
+}
+
 // AllowType controls whether to permit binding of a method, if a method uses
 // this type in its parameter list or return type.
 // Any type not permitted by AllowClass is also not permitted by this method.

--- a/qt6/gen_qstringconverter_base.cpp
+++ b/qt6/gen_qstringconverter_base.cpp
@@ -12,14 +12,6 @@ extern "C" {
 } /* extern C */
 #endif
 
-QStringConverterBase* QStringConverterBase_new(QStringConverterBase* param1) {
-	return new QStringConverterBase(*param1);
-}
-
-QStringConverterBase* QStringConverterBase_new2() {
-	return new QStringConverterBase();
-}
-
 void QStringConverter_virtbase(QStringConverter* src, QStringConverterBase** outptr_QStringConverterBase) {
 	*outptr_QStringConverterBase = static_cast<QStringConverterBase*>(src);
 }

--- a/qt6/gen_qstringconverter_base.go
+++ b/qt6/gen_qstringconverter_base.go
@@ -71,18 +71,6 @@ func UnsafeNewQStringConverterBase(h unsafe.Pointer) *QStringConverterBase {
 	return newQStringConverterBase((*C.QStringConverterBase)(h))
 }
 
-// NewQStringConverterBase constructs a new QStringConverterBase object.
-func NewQStringConverterBase(param1 *QStringConverterBase) *QStringConverterBase {
-
-	return newQStringConverterBase(C.QStringConverterBase_new(param1.cPointer()))
-}
-
-// NewQStringConverterBase2 constructs a new QStringConverterBase object.
-func NewQStringConverterBase2() *QStringConverterBase {
-
-	return newQStringConverterBase(C.QStringConverterBase_new2())
-}
-
 type QStringConverter struct {
 	h *C.QStringConverter
 	*QStringConverterBase

--- a/qt6/gen_qstringconverter_base.h
+++ b/qt6/gen_qstringconverter_base.h
@@ -28,8 +28,6 @@ typedef struct QStringConverterBase QStringConverterBase;
 typedef struct QStringConverterBase__State QStringConverterBase__State;
 #endif
 
-QStringConverterBase* QStringConverterBase_new(QStringConverterBase* param1);
-QStringConverterBase* QStringConverterBase_new2();
 
 void QStringConverter_virtbase(QStringConverter* src, QStringConverterBase** outptr_QStringConverterBase);
 bool QStringConverter_isValid(const QStringConverter* self);


### PR DESCRIPTION
Fixes: #168 

The CI `miqt_linux64_qt6_8` stage only pinned to Qt 6.8, not to any particular subversion, so it automatically received the 6.8.2 update. All CI runs for other in-progress PRs will fail until they are rebased on top of this fix.