### PR TITLE
Docker: Add qt6 static mingw container

### DIFF
--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -171,33 +171,33 @@ jobs:
     - name: Verify that package exists
       run: test -f examples/android/android-build/build/outputs/apk/debug/android-build-debug.apk
 
-  miqt_android_qt6:
-    runs-on: ubuntu-24.04
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Android armv8a docker build
-      run: docker build -t miqt/android:qt6 -f docker/android-armv8a-go1.23-qt6.6-dynamic.Dockerfile .
-
-    - name: Cache GOCACHE
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/go-build
-        key: android-qt6-armv8a-gocache
-
-    - name: Android compile app as c-shared my_go_app.so
-      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src/examples/android6 miqt/android:qt6 go build -buildmode c-shared -ldflags "-s -w -extldflags -Wl,-soname,my_go_app.so" -o android-build/libs/arm64-v8a/my_go_app.so
-
-    - name: Android generate libRealAppName.so linking stub
-      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src/examples/android6 miqt/android:qt6 android-stub-gen.sh my_go_app.so AndroidMain android-build/libs/arm64-v8a/libRealAppName_arm64-v8a.so --qt6
-
-    - name: Android generate json packaging metadata
-      run: docker run --rm -v $(pwd):/src -w /src/examples/android6 miqt/android:qt6 android-mktemplate.sh RealAppName deployment-settings.json
-
-    - name: Android build APK package
-      run: docker run --rm -v $(pwd):/src -w /src/examples/android6 miqt/android:qt6 androiddeployqt --input ./deployment-settings.json --output ./android-build/
-
-    - name: Verify that package exists
-      run: test -f examples/android6/android-build/build/outputs/apk/debug/android-build-debug.apk
+#  miqt_android_qt6:
+#    runs-on: ubuntu-24.04
+#
+#    steps:
+#    - name: Checkout
+#      uses: actions/checkout@v4
+#
+#    - name: Android armv8a docker build
+#      run: docker build -t miqt/android:qt6 -f docker/android-armv8a-go1.23-qt6.6-dynamic.Dockerfile .
+#
+#    - name: Cache GOCACHE
+#      uses: actions/cache@v4
+#      with:
+#        path: ~/.cache/go-build
+#        key: android-qt6-armv8a-gocache
+#
+#    - name: Android compile app as c-shared my_go_app.so
+#      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src/examples/android6 miqt/android:qt6 go build -buildmode c-shared -ldflags "-s -w -extldflags -Wl,-soname,my_go_app.so" -o android-build/libs/arm64-v8a/my_go_app.so
+#
+#    - name: Android generate libRealAppName.so linking stub
+#      run: docker run -v ~/.cache/go-build:/root/.cache/go-build -v $PWD:/src -w /src/examples/android6 miqt/android:qt6 android-stub-gen.sh my_go_app.so AndroidMain android-build/libs/arm64-v8a/libRealAppName_arm64-v8a.so --qt6
+#
+#    - name: Android generate json packaging metadata
+#      run: docker run --rm -v $(pwd):/src -w /src/examples/android6 miqt/android:qt6 android-mktemplate.sh RealAppName deployment-settings.json
+#
+#    - name: Android build APK package
+#      run: docker run --rm -v $(pwd):/src -w /src/examples/android6 miqt/android:qt6 androiddeployqt --input ./deployment-settings.json --output ./android-build/
+#
+#    - name: Verify that package exists
+#      run: test -f examples/android6/android-build/build/outputs/apk/debug/android-build-debug.apk

--- a/docker/win64-cross-go1.23-qt6.8-static.Dockerfile
+++ b/docker/win64-cross-go1.23-qt6.8-static.Dockerfile
@@ -1,0 +1,60 @@
+FROM debian:bookworm
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -qyy --no-install-recommends \
+        autoconf automake autopoint bash bison bzip2 flex g++ g++-multilib \
+        gettext git gperf intltool libltdl-dev libgdk-pixbuf2.0-dev libgl-dev \
+        libpcre3-dev libssl-dev libtool-bin libxml-parser-perl lzip make \
+        openssl p7zip-full patch perl python3 python3-distutils python3-mako \
+        python3-packaging python3-pkg-resources python3-setuptools \
+        python-is-python3 ruby sed sqlite3 unzip wget xz-utils && \
+    apt-get clean
+
+
+# Install MXE
+# Use a pinned commit from 2025-02-21 with Qt 6.8.2
+
+RUN cd /usr/lib/ && \
+    git clone https://github.com/mxe/mxe.git && \
+    cd mxe && \
+    git reset --hard 2bf85f28165cefbce457a79cc0c69007455b025a
+
+
+# Compile Qt6 static with MXE
+# This downloads files from the internet and takes circa 45 minutes
+# Clean up temporary directories: ccache (1.5GB), pkg downloads (337MB)
+
+RUN cd /usr/lib/mxe && \
+    make MXE_TARGETS='x86_64-w64-mingw32.static' qt6-qtbase && \
+    rm -rf /usr/lib/mxe/.ccache && \
+    rm -rf /usr/lib/mxe/pkg
+
+
+# Install Go
+
+RUN wget 'https://go.dev/dl/go1.23.6.linux-amd64.tar.gz' && \
+	tar x -C /usr/local/ -f go1.23.6.linux-amd64.tar.gz && \
+	rm go1.23.6.linux-amd64.tar.gz
+
+
+# MXE does not install pkg-config files for mingw32.static qt6
+# Invent some based on patching the x86_64-pc-linux-gnu ones
+
+RUN \
+    cp /usr/lib/mxe/usr/x86_64-pc-linux-gnu/qt6/lib/pkgconfig/Qt6* /usr/lib/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig/ && \
+    find /usr/lib/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig/ -name 'Qt6*.pc' -exec sed -i -re 's~x86_64-pc-linux-gnu~x86_64-w64-mingw32.static~; s~linux-g\+\+~win32-g++~' {} \; && \
+    echo 'Libs: -lgdi32 -lcomdlg32 -loleaut32 -limm32 -lwinmm -lws2_32 -lole32 -luuid -luser32 -ladvapi32 -lnetapi32 -lversion -lauthz -ldwmapi -ld3d11 -ld3d12 -lsynchronization -ldxgi -luxtheme -ldwrite -luserenv -lmpr -lruntimeobject' >> /usr/lib/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig/Qt6Platform.pc && \
+    echo 'Requires: libpcre2-16 zlib libzstd libpng freetype2 harfbuzz' >> /usr/lib/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig/Qt6Platform.pc
+
+
+# Environment variables
+
+ENV PATH=/usr/local/go/bin:/usr/lib/mxe/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PKG_CONFIG=x86_64-w64-mingw32.static-pkg-config
+ENV PKG_CONFIG_PATH=/usr/lib/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig
+ENV CC=x86_64-w64-mingw32.static-gcc
+ENV CXX=x86_64-w64-mingw32.static-g++
+ENV CGO_ENABLED=1
+ENV GOOS=windows
+ENV GOARCH=amd64
+ENV GOFLAGS='-buildvcs=false'

--- a/qt6/cflags_windowsqtstatic.cpp
+++ b/qt6/cflags_windowsqtstatic.cpp
@@ -1,0 +1,7 @@
+#ifdef MIQT_WINDOWSQTSTATIC
+
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN (QModernWindowsStylePlugin);
+
+#endif

--- a/qt6/cflags_windowsqtstatic.go
+++ b/qt6/cflags_windowsqtstatic.go
@@ -1,0 +1,13 @@
+//go:build windowsqtstatic
+// +build windowsqtstatic
+
+package qt6
+
+// Statically link the Qt platform plugins
+
+/*
+#cgo windowsqtstatic CXXFLAGS: -DMIQT_WINDOWSQTSTATIC
+#cgo amd64 LDFLAGS: -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt6/plugins/platforms -lqwindows -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt6/plugins/styles -lqmodernwindowsstyle -ld3d9 -lsetupapi -lshcore -lwtsapi32 -lfreetype
+#cgo 386 LDFLAGS: -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt6/plugins/platforms -lqwindows -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt6/plugins/styles -lqmodernwindowsstyle -ld3d9 -lsetupapi -lshcore -lwtsapi32 -lfreetype
+*/
+import "C"


### PR DESCRIPTION
Fixes: #74 

Updates: #181 (disabled flakey CI pipeline)

The container does a from-source build of Qt from a pinned MXE commit. The platform plugin is statically linked (now `QModernWindowsStylePlugin` instead of `QWindowsVistaStylePlugin`).

![Screenshot_20250223_192915](https://github.com/user-attachments/assets/36989c6d-4cb0-4c6a-97c8-cc984dcb2502)

Usage:

```bash
docker build -t miqt/winqt6static:latest -f docker/win64-cross-go1.23-qt6.8-static.Dockerfile .
docker run --rm -v $(pwd):/src -w /src/examples/helloworld6 miqt/winqt6static:latest /bin/bash -c 'go build --tags=windowsqtstatic -ldflags "-s -w -H windowsgui"'
```

The file size is somewhat large, but it does contain a whole copy of Qt of course. It seems like UPX cannot be used with this binary.

|File|Build|Size (bytes)|Size (human)
|---|---|---|---
|helloworld6.exe|go build -ldflags -s -w|52121600|50M
|helloworld6.exe|upx --force --lzma // upx 4.2.2: binary does not start properly|11785216|12M