### PR TITLE
Qt 6.9: Return type for QObjectData_dynamicMetaObject is now const

### DIFF
--- a/cmd/genbindings/config-allowlist.go
+++ b/cmd/genbindings/config-allowlist.go
@@ -651,6 +651,10 @@ func ApplyQuirks(className string, mm *CppMethod) {
 		mm.BecomesNonConstInVersion = addr("6.7")
 	}
 
+	if className == "QObjectData" && mm.MethodName == "dynamicMetaObject" {
+		mm.ReturnType.BecomesConstInVersion = addr("6.9")
+	}
+
 	if className == "QFileDialog" && mm.MethodName == "saveFileContent" && mm.IsStatic {
 		// The prototype was changed from
 		// [Qt 5 - 6.6] void QFileDialog::saveFileContent(const QByteArray &fileContent, const QString &fileNameHint = QString())

--- a/cmd/genbindings/intermediate.go
+++ b/cmd/genbindings/intermediate.go
@@ -16,7 +16,8 @@ type CppParameter struct {
 	Optional      bool
 	NoExcept      bool
 
-	QtCppOriginalType *CppParameter // If we rewrote QStringList->QList<String>, this field contains the original QStringList. Otherwise, it's blank
+	QtCppOriginalType     *CppParameter // If we rewrote QStringList->QList<String>, this field contains the original QStringList. Otherwise, it's blank
+	BecomesConstInVersion *string       // "6,9"
 }
 
 func (p CppParameter) String() string {

--- a/qt6/gen_qobject.cpp
+++ b/qt6/gen_qobject.cpp
@@ -36,7 +36,13 @@ void miqt_exec_callback_QObject_disconnectNotify(QObject*, intptr_t, QMetaMethod
 } /* extern C */
 #endif
 
+// This method's return type was changed from non-const to const in Qt 6.9
+#if QT_VERSION >= QT_VERSION_CHECK(6,9,0)
+const QMetaObject* QObjectData_dynamicMetaObject(const QObjectData* self) {
+#else
 QMetaObject* QObjectData_dynamicMetaObject(const QObjectData* self) {
+#endif
+
 	return self->dynamicMetaObject();
 }
 

--- a/qt6/gen_qobject.h
+++ b/qt6/gen_qobject.h
@@ -14,6 +14,11 @@
 extern "C" {
 #endif
 
+// Based on the macro from Qt (LGPL v3), see https://www.qt.io/qt-licensing
+// Macro is trivial and used here under fair use
+// Usage does not imply derivation
+#define QT_VERSION_CHECK(major, minor, patch) ((major<<16)|(minor<<8)|(patch))
+
 #ifdef __cplusplus
 class QAnyStringView;
 class QBindingStorage;
@@ -48,7 +53,12 @@ typedef struct QTimerEvent QTimerEvent;
 typedef struct QVariant QVariant;
 #endif
 
+// This method's return type was changed from non-const to const in Qt 6.9
+#if QT_VERSION >= QT_VERSION_CHECK(6,9,0)
+const QMetaObject* QObjectData_dynamicMetaObject(const QObjectData* self);
+#else
 QMetaObject* QObjectData_dynamicMetaObject(const QObjectData* self);
+#endif
 void QObjectData_delete(QObjectData* self);
 
 QObject* QObject_new();


### PR DESCRIPTION
* Closes #194