### PR TITLE
webchannel/cflags.go: Add Qt6WebChannelQuick to the pkg-config

### DIFF
--- a/docker/genbindings.Dockerfile
+++ b/docker/genbindings.Dockerfile
@@ -14,6 +14,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         qt6-declarative-dev \
         qt6-multimedia-dev \
         qt6-svg-dev \
+        qt6-webchannel-dev \
         qt6-webengine-dev \
         libqscintilla2-qt5-dev \
         libqscintilla2-qt6-dev \

--- a/qt6/webchannel/cflags.go
+++ b/qt6/webchannel/cflags.go
@@ -1,6 +1,6 @@
 package webchannel
 
 /*
-#cgo pkg-config: Qt6WebChannel
+#cgo pkg-config: Qt6WebChannel Qt6WebChannelQuick
 */
 import "C"


### PR DESCRIPTION
This should aid the resolution for QQmlWebChannel

This should mean that this class can be moved back into the parent directory and the code can be removed, hopefully simplifying long-term maintenance.