### PR TITLE
Windows: Move static build definitions out of the main package

### DIFF
--- a/docker/win32-cross-go1.23-qt5.15-static.Dockerfile
+++ b/docker/win32-cross-go1.23-qt5.15-static.Dockerfile
@@ -20,3 +20,7 @@ ENV GOOS=windows
 ENV GOARCH=386
 ENV CGO_ENABLED=1
 ENV GOFLAGS=-buildvcs=false
+
+# Some static Qt compliation flags are not part of the pkg-config file
+# Export them manually in the environment
+ENV CGO_LDFLAGS='-L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme'

--- a/docker/win64-cross-go1.19-qt5.15-static.Dockerfile
+++ b/docker/win64-cross-go1.19-qt5.15-static.Dockerfile
@@ -19,3 +19,7 @@ ENV PKG_CONFIG=x86_64-w64-mingw32.static-pkg-config
 ENV GOOS=windows
 ENV CGO_ENABLED=1
 ENV GOFLAGS=-buildvcs=false
+
+# Some static Qt compliation flags are not part of the pkg-config file
+# Export them manually in the environment
+ENV CGO_LDFLAGS='-L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme'

--- a/docker/win64-cross-go1.23-qt5.15-static.Dockerfile
+++ b/docker/win64-cross-go1.23-qt5.15-static.Dockerfile
@@ -19,3 +19,7 @@ ENV PKG_CONFIG=x86_64-w64-mingw32.static-pkg-config
 ENV GOOS=windows
 ENV CGO_ENABLED=1
 ENV GOFLAGS=-buildvcs=false
+
+# Some static Qt compliation flags are not part of the pkg-config file
+# Export them manually in the environment
+ENV CGO_LDFLAGS='-L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme'

--- a/docker/win64-cross-go1.23-qt6.8-static.Dockerfile
+++ b/docker/win64-cross-go1.23-qt6.8-static.Dockerfile
@@ -58,3 +58,7 @@ ENV CGO_ENABLED=1
 ENV GOOS=windows
 ENV GOARCH=amd64
 ENV GOFLAGS='-buildvcs=false'
+
+# Some static Qt compliation flags are not part of the pkg-config file
+# Export them manually in the environment
+ENV CGO_LDFLAGS='-L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt6/plugins/platforms -lqwindows -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt6/plugins/styles -lqmodernwindowsstyle -ld3d9 -lsetupapi -lshcore -lwtsapi32 -lfreetype'

--- a/qt/cflags_windowsqtstatic.go
+++ b/qt/cflags_windowsqtstatic.go
@@ -12,7 +12,6 @@ package qt
 
 /*
 #cgo windowsqtstatic CXXFLAGS: -DMIQT_WINDOWSQTSTATIC
-#cgo amd64 LDFLAGS: -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme
-#cgo 386 LDFLAGS: -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/plugins/platforms -lqwindows -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5PlatformCompositorSupport -lQt5AccessibilitySupport -lQt5WindowsUIAutomationSupport -lwtsapi32 -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/plugins/styles -lqwindowsvistastyle -luxtheme
+#cgo pkg-config: --static QtWidgets
 */
 import "C"

--- a/qt6/cflags_windowsqtstatic.go
+++ b/qt6/cflags_windowsqtstatic.go
@@ -7,7 +7,6 @@ package qt6
 
 /*
 #cgo windowsqtstatic CXXFLAGS: -DMIQT_WINDOWSQTSTATIC
-#cgo amd64 LDFLAGS: -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt6/plugins/platforms -lqwindows -L/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt6/plugins/styles -lqmodernwindowsstyle -ld3d9 -lsetupapi -lshcore -lwtsapi32 -lfreetype
-#cgo 386 LDFLAGS: -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt6/plugins/platforms -lqwindows -L/usr/lib/mxe/usr/i686-w64-mingw32.static/qt6/plugins/styles -lqmodernwindowsstyle -ld3d9 -lsetupapi -lshcore -lwtsapi32 -lfreetype
+#cgo pkg-config: --static Qt6Widgets
 */
 import "C"


### PR DESCRIPTION
Fixes: #235 

Until now, building a static binary for Windows with `--tags=windowsqtstatic` added some LDFLAGS specifically for MXE Qt. However MSYS2 Qt uses different paths.

To be fair, move all the LDFLAGS customization out of the main cflags.go file.

- For MXE users, the required LDFLAGS are placed in the Dockerfile and will be used automatically, so it should be a seamless change.
- For MSYS2 users, a full set of instructions are added to the README.md file.

---

Extra test notes
- [X] Manual test of all MSYS2 steps
- [X] Manual test of `miqt-docker win32-cross-go1.23-qt5.15-static go build -ldflags '-s -w'`
    - [X] Verify that `objdump -p helloworld.exe | fgrep -i 'dll name'` shows only common windows dlls