### PR TITLE
Minor fixes for qt5 static builds on windows, for go mod vendor

### DIFF
--- a/qt/cflags.go
+++ b/qt/cflags.go
@@ -6,3 +6,7 @@ package qt
 #cgo pkg-config: Qt5Widgets
 */
 import "C"
+
+import (
+	_ "github.com/mappu/miqt/libmiqt"
+)

--- a/qt/cflags_windowsqtstatic.go
+++ b/qt/cflags_windowsqtstatic.go
@@ -12,6 +12,6 @@ package qt
 
 /*
 #cgo windowsqtstatic CXXFLAGS: -DMIQT_WINDOWSQTSTATIC
-#cgo pkg-config: --static QtWidgets
+#cgo pkg-config: --static Qt5Widgets
 */
 import "C"

--- a/qt6/cflags.go
+++ b/qt6/cflags.go
@@ -4,3 +4,7 @@ package qt6
 #cgo pkg-config: Qt6Widgets
 */
 import "C"
+
+import (
+	_ "github.com/mappu/miqt/libmiqt"
+)


### PR DESCRIPTION
Fixes: #252

- Fix an issue with the libmiqt package going missing when using `go mod vendor`

Fixes: #253 

- Fix an issue with pkg-config file names for building Qt5 statically on Windows
