### PR TITLE
miqt-docker: show docker's output instead of discarding it

### DIFF
--- a/cmd/miqt-docker/docker.go
+++ b/cmd/miqt-docker/docker.go
@@ -157,6 +157,7 @@ func dockerFindImage(repository, tag string) (*dockerImage, error) {
 func dockerBuild(dockerfile []byte, repository, tag string) error {
 	cmd := dockerCommand(`build`, `-t`, repository+`:`+tag, `-t`, repository+`:latest`, `-`)
 	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 	cmd.Stdin = bytes.NewReader(dockerfile)
 
 	return cmd.Run()


### PR DESCRIPTION
We really want to know what docker is doing, specially when it takes a long time to download stuff and when it gets stuck.