### PR TITLE
CI: fix build failures in miqt_android_qt5 caused by low CI runner disk space

### DIFF
--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -125,6 +125,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       
+    # Low disk space (@ref https://github.com/mappu/miqt/issues/289 )
+    - name: Clean up runner disk space
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+        sudo docker builder prune -a
+        df -h
+
     - name: Android compile
       run: |
         make cmd/miqt-docker/miqt-docker


### PR DESCRIPTION
Fixes: #289 

GitHub automatically updated the Linux runtime environment and now it has less free disk space. This is causing the `miqt_android_qt5` stage to fail.

Add some magic commands from google to remove runtimes and libraries not needed by Miqt from the GitHub runner VM.