### PR TITLE
docker: add linux64-go1.25-qt6.4-dynamic container

### DIFF
--- a/docker/linux64-go1.25-qt6.4-dynamic.Dockerfile
+++ b/docker/linux64-go1.25-qt6.4-dynamic.Dockerfile
@@ -1,0 +1,16 @@
+# This container is
+# - Baseline debian 12 for broad Qt 6 compatibility
+# - Added recent Go compiler
+
+FROM debian:bookworm
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -qyy wget qt6-base-dev build-essential pkg-config && \
+    apt-get clean
+
+RUN wget 'https://go.dev/dl/go1.25.4.linux-amd64.tar.gz' && \
+	tar x -C /usr/local/ -f go1.25.4.linux-amd64.tar.gz && \
+	rm go1.25.4.linux-amd64.tar.gz
+	
+ENV PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV CGO_ENABLED=1


### PR DESCRIPTION
Allow building deb12-compatible release binaries from another/newer distro.

There was already a go1.19 version of this environment, this is the same but with a newer toolchain installed.