### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=C


### PR DESCRIPTION
This is a cosmetic change to have the header files properly identified as C rather than the current C++ to accurately reflect the project's structure.