### PR TITLE
mainthread: add missing C++ standard flags

### DIFF
--- a/qt/mainthread/mainthread.go
+++ b/qt/mainthread/mainthread.go
@@ -6,6 +6,7 @@ import (
 )
 
 /*
+#cgo CXXFLAGS: -std=c++11
 #cgo pkg-config: Qt5Core
 
 #include "mainthread.h"

--- a/qt6/mainthread/mainthread.go
+++ b/qt6/mainthread/mainthread.go
@@ -6,6 +6,7 @@ import (
 )
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Core
 
 #include "mainthread.h"


### PR DESCRIPTION
The mainthread packages compile mainthread.cpp which includes Qt headers, but unlike qt/cflags.go they do not set the C++ standard. CGo directives don't propagate across package boundaries, so when the system C++ compiler defaults to an older standard (e.g. MXE's MinGW GCC), Qt headers fail to parse.

Add -std=c++11 for Qt5 and -std=c++17 for Qt6, matching the minimum requirements of each Qt version.

Reproducible with:
  miqt-docker win64-cross-go1.23-qt5.15-static \
    go build github.com/mappu/miqt/qt/mainthread

Fixes #331