### PR TITLE
mainthread: avoid deadlock when Wait is called from the main thread

### DIFF
--- a/qt/mainthread/mainthread.cpp
+++ b/qt/mainthread/mainthread.cpp
@@ -1,5 +1,6 @@
 #include <QMetaObject>
 #include <QCoreApplication>
+#include <QThread>
 
 #include "mainthread.h"
 
@@ -11,4 +12,14 @@ void mainthread_exec(intptr_t cb) {
     QMetaObject::invokeMethod(qApp, [=]{
         mainthread_exec_handle(cb);
     }, Qt::QueuedConnection);
+}
+
+// Returns 1 if the calling thread is the Qt main thread, 0 otherwise.
+// Useful to skip queueing when already on the main thread (would deadlock).
+int mainthread_is_current(void) {
+    QCoreApplication* app = QCoreApplication::instance();
+    if (app == nullptr) {
+        return 0;
+    }
+    return QThread::currentThread() == app->thread() ? 1 : 0;
 }

--- a/qt/mainthread/mainthread.go
+++ b/qt/mainthread/mainthread.go
@@ -22,10 +22,26 @@ func Start(gofunc func()) {
 	C.mainthread_exec(C.intptr_t(h))
 }
 
+// IsCurrent reports whether the calling thread is the Qt main thread.
+func IsCurrent() bool {
+	return C.mainthread_is_current() != 0
+}
+
 // Wait runs the callback in the main Qt thread. You should use this whenever
 // accessing the main Qt GUI from inside a goroutine.
 // The call blocks until the callback is executed in the main thread's eventloop.
-func Wait(gofunc func()) {	
+//
+// If called from the Qt main thread itself, the callback is invoked directly:
+// queueing onto the main thread's event loop and then waiting for it would
+// deadlock (the main thread is blocked in wg.Wait() and can't process the
+// queued event). This makes Wait safe to call from code that may run on
+// either a goroutine or the main thread (e.g. a slot invoked indirectly from
+// both an event handler and a background worker).
+func Wait(gofunc func()) {
+	if IsCurrent() {
+		gofunc()
+		return
+	}
 	// It's possible to use Qt::BlockingQueuedConnection to implement the
 	// blocking, but it has a deadlock risk
 	var wg sync.WaitGroup

--- a/qt/mainthread/mainthread.h
+++ b/qt/mainthread/mainthread.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 void mainthread_exec(intptr_t cb);
+int mainthread_is_current(void);
 
 #ifdef __cplusplus
 }

--- a/qt6/mainthread/mainthread.cpp
+++ b/qt6/mainthread/mainthread.cpp
@@ -1,5 +1,6 @@
 #include <QMetaObject>
 #include <QCoreApplication>
+#include <QThread>
 
 #include "mainthread.h"
 
@@ -11,4 +12,14 @@ void mainthread_exec(intptr_t cb) {
     QMetaObject::invokeMethod(qApp, [=]{
         mainthread_exec_handle(cb);
     }, Qt::QueuedConnection);
+}
+
+// Returns 1 if the calling thread is the Qt main thread, 0 otherwise.
+// Useful to skip queueing when already on the main thread (would deadlock).
+int mainthread_is_current(void) {
+    QCoreApplication* app = QCoreApplication::instance();
+    if (app == nullptr) {
+        return 0;
+    }
+    return QThread::currentThread() == app->thread() ? 1 : 0;
 }

--- a/qt6/mainthread/mainthread.go
+++ b/qt6/mainthread/mainthread.go
@@ -22,10 +22,26 @@ func Start(gofunc func()) {
 	C.mainthread_exec(C.intptr_t(h))
 }
 
+// IsCurrent reports whether the calling thread is the Qt main thread.
+func IsCurrent() bool {
+	return C.mainthread_is_current() != 0
+}
+
 // Wait runs the callback in the main Qt thread. You should use this whenever
 // accessing the main Qt GUI from inside a goroutine.
 // The call blocks until the callback is executed in the main thread's eventloop.
-func Wait(gofunc func()) {	
+//
+// If called from the Qt main thread itself, the callback is invoked directly:
+// queueing onto the main thread's event loop and then waiting for it would
+// deadlock (the main thread is blocked in wg.Wait() and can't process the
+// queued event). This makes Wait safe to call from code that may run on
+// either a goroutine or the main thread (e.g. a slot invoked indirectly from
+// both an event handler and a background worker).
+func Wait(gofunc func()) {
+	if IsCurrent() {
+		gofunc()
+		return
+	}
 	// It's possible to use Qt::BlockingQueuedConnection to implement the
 	// blocking, but it has a deadlock risk
 	var wg sync.WaitGroup

--- a/qt6/mainthread/mainthread.h
+++ b/qt6/mainthread/mainthread.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 void mainthread_exec(intptr_t cb);
+int mainthread_is_current(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## mainthread: avoid deadlock when `Wait` is called from the main thread

### Problem

`mainthread.Wait` queues the callback onto the Qt main thread's event loop and blocks on a `sync.WaitGroup`. If the caller is already the main thread, it blocks itself: the queued event never runs (the main thread is stuck in `wg.Wait()` and never returns to its event loop), and `Wait` hangs forever.

This is easy to hit in practice. Consider a helper function that touches GUI state:

```go
func updateLabel(text string) {
    mainthread.Wait(func() {
        myLabel.SetText(text)
    })
}
```

If `updateLabel` is called from a background goroutine, this works correctly. If the same helper is later reused from a Qt slot (e.g. a button-click handler) — perhaps via several layers of indirection — the app silently deadlocks. Callers often can't easily know which thread they're on, especially in deep call chains.

### Reproduction

```go
package main

import (
    "os"
    "github.com/mappu/miqt/qt"
    "github.com/mappu/miqt/qt/mainthread"
)

func main() {
    qt.NewQApplication(os.Args)
    btn := qt.NewQPushButton3("Click to hang")
    btn.OnPressed(func() {
        mainthread.Wait(func() {
            btn.SetText("never reached")
        })
    })
    btn.Show()
    qt.QApplication_Exec()
}
```

Click the button → app hangs.

### Fix

Check whether the current thread is the Qt main thread, and if so, invoke the callback directly without going through the event loop.

The check is implemented in C++ using `QThread::currentThread() == QCoreApplication::instance()->thread()` — the standard Qt idiom — and exposed to Go as `mainthread.IsCurrent()`.

After the fix, the example above works: clicking the button updates its label, because `Wait` notices it's already on the main thread and calls the function directly.

### Public API

A new `mainthread.IsCurrent() bool` is added for users who want to make the same decision in their own code (e.g. picking between sync and async paths, or asserting thread invariants).

### Performance

`IsCurrent()` adds one CGo call + a `QThread::currentThread()` lookup + a pointer comparison to every `Wait`. In context this is negligible:

- **From a goroutine** (the common case): `Wait` already does a CGo call, a `QMetaObject::invokeMethod` queued dispatch (event allocation, event-loop mutex, append, futex wait/wake, context switch through the event loop, second CGo bridge for the callback). The extra check is well under 1% of the existing cost.
- **From the main thread**: the check avoids the queued-dispatch path entirely. The cost goes from infinite (deadlock) to a single CGo call.

The only scenario where the overhead would matter is calling `Wait` from a tight loop on a goroutine — but that's misuse (you'd batch instead).

### Scope

Both `qt/mainthread` and `qt6/mainthread` packages get the same fix.
