### PR TITLE
genbindings: fix use-after-free in virtual-override callbacks returning heap CABI types

### DIFF
--- a/cmd/genbindings/emitcabi.go
+++ b/cmd/genbindings/emitcabi.go
@@ -265,6 +265,30 @@ func makeNamePrefix(in string) string {
 	return replacer.Replace(in)
 }
 
+// emitCABI2CppFreeReturn frees the malloc'd C memory of a CABI value that a Go
+// virtual-override callback returned and handed to C++ (the Go side no longer
+// defer-frees it — that was a use-after-free). Mirrors the heap-allocating cases
+// of emitCABI2CppForwarding; emits nothing for value/pointer types.
+func emitCABI2CppFreeReturn(p CppParameter, varname, indent string) string {
+	if p.ParameterType == "QString" || p.ParameterType == "QByteArray" {
+		return indent + "free(" + varname + ".data);\n"
+	}
+	if listType, _, ok := p.QListOf(); ok {
+		np := makeNamePrefix(varname) + "_free"
+		s := indent + listType.RenderTypeCabi() + "* " + np + "_arr = static_cast<" + listType.RenderTypeCabi() + "*>(" + varname + ".data);\n"
+		s += indent + "for(size_t i = 0; i < " + varname + ".len; ++i) {\n"
+		listType.ParameterName = np + "_arr[i]"
+		s += emitCABI2CppFreeReturn(listType, np+"_arr[i]", indent+"\t")
+		s += indent + "}\n"
+		s += indent + "free(" + varname + ".data);\n"
+		return s
+	}
+	// QMap/QPair and value/pointer types: no malloc'd top-level buffer is handed
+	// across for virtual returns in practice; leave a no-op rather than risk a
+	// wrong free.
+	return ""
+}
+
 func emitCABI2CppForwarding(p CppParameter, indent string) (preamble string, forwarding string) {
 
 	nameprefix := makeNamePrefix(p.cParameterName())
@@ -1042,7 +1066,7 @@ extern "C" {
 
 				{
 					var maybeReturn, maybeReturn2 string
-					var returnTransformP, returnTransformF string
+					var returnTransformP, returnTransformF, returnFree string
 					if !m.ReturnType.Void() {
 						maybeReturn = "return "
 
@@ -1050,6 +1074,9 @@ extern "C" {
 						returnParam := m.ReturnType // copy
 						returnParam.ParameterName = "callback_return_value"
 						returnTransformP, returnTransformF = emitCABI2CppForwarding(returnParam, "\t\t")
+						// The Go callback hands us malloc'd CABI memory and no longer frees it;
+						// free it here after the copy into the C++ return type.
+						returnFree = emitCABI2CppFreeReturn(returnParam, "callback_return_value", "\t\t")
 					}
 
 					handleVarname := "handle__" + m.SafeMethodName()
@@ -1100,6 +1127,7 @@ extern "C" {
 							signalCode +
 							"\t\t" + maybeReturn2 + cabiCallbackName(c, m) + "(" + strings.Join(paramArgs, `, `) + ");\n" +
 							returnTransformP +
+							returnFree +
 							ifv(maybeReturn == "", "", "\t\treturn "+returnTransformF+";") + "\n" +
 							"\t}\n" +
 

--- a/cmd/genbindings/emitcabi.go
+++ b/cmd/genbindings/emitcabi.go
@@ -275,11 +275,19 @@ func emitCABI2CppFreeReturn(p CppParameter, varname, indent string) string {
 	}
 	if listType, _, ok := p.QListOf(); ok {
 		np := makeNamePrefix(varname) + "_free"
-		s := indent + listType.RenderTypeCabi() + "* " + np + "_arr = static_cast<" + listType.RenderTypeCabi() + "*>(" + varname + ".data);\n"
-		s += indent + "for(size_t i = 0; i < " + varname + ".len; ++i) {\n"
 		listType.ParameterName = np + "_arr[i]"
-		s += emitCABI2CppFreeReturn(listType, np+"_arr[i]", indent+"\t")
-		s += indent + "}\n"
+		inner := emitCABI2CppFreeReturn(listType, np+"_arr[i]", indent+"\t")
+		s := ""
+		// Only emit the per-element loop when there is actually an element to
+		// free; for borrowed-pointer element types (e.g. QModelIndex*) the inner
+		// free is empty, so emitting the loop would leave dead code plus an
+		// unused _arr variable (-Wunused-variable).
+		if inner != "" {
+			s += indent + listType.RenderTypeCabi() + "* " + np + "_arr = static_cast<" + listType.RenderTypeCabi() + "*>(" + varname + ".data);\n"
+			s += indent + "for(size_t i = 0; i < " + varname + ".len; ++i) {\n"
+			s += inner
+			s += indent + "}\n"
+		}
 		s += indent + "free(" + varname + ".data);\n"
 		return s
 	}

--- a/cmd/genbindings/emitgo.go
+++ b/cmd/genbindings/emitgo.go
@@ -327,6 +327,22 @@ func (gfs *goFileState) emitParametersGo2CABIForwarding(m CppMethod) (preamble s
 	return preamble, strings.Join(tmp, ", ")
 }
 
+// stripDeferCFree removes `defer C.free(...)` lines from a Go2CABI preamble. It
+// is used for virtual-override callback RETURN values, whose CABI memory must
+// outlive the callback's return (the C++ caller copies it, then frees) — unlike
+// argument forwarding, where defer-freeing on return is correct.
+func stripDeferCFree(preamble string) string {
+	lines := strings.Split(preamble, "\n")
+	out := lines[:0]
+	for _, ln := range lines {
+		if strings.Contains(ln, "defer C.free(") {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n")
+}
+
 func (gfs *goFileState) emitParameterGo2CABIForwarding(p CppParameter) (preamble string, rvalue string) {
 
 	nameprefix := makeNamePrefix(p.goParameterName())
@@ -1123,6 +1139,13 @@ import "C"
 					virtualRetP := m.ReturnType // copy
 					virtualRetP.ParameterName = "virtualReturn"
 					binding, rvalue := gfs.emitParameterGo2CABIForwarding(virtualRetP)
+					// A virtual-override callback hands ownership of any heap-allocated
+					// CABI return memory to the C++ caller, which copies it into the real
+					// Qt type. The `defer C.free(...)` emitted for argument forwarding would
+					// run on THIS function's return — before the C++ caller reads the data —
+					// a use-after-free (e.g. QAbstractItemModel::mimeTypes -> qBadAlloc).
+					// Strip them so the memory outlives the return; the C++ trampoline frees.
+					binding = stripDeferCFree(binding)
 					ret.WriteString(binding + "\n")
 					ret.WriteString("return " + rvalue + "\n")
 				}

--- a/cmd/genbindings/emitgo_uaf_test.go
+++ b/cmd/genbindings/emitgo_uaf_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripDeferCFree verifies the fix for the virtual-override callback
+// use-after-free (e.g. QAbstractItemModel::mimeTypes -> qBadAlloc). A callback
+// that returns a heap CABI type must NOT defer-free its C memory on return — the
+// C++ caller reads/copies it afterward. stripDeferCFree removes exactly those
+// defer-frees from the Go2CABI preamble while leaving allocations intact.
+func TestStripDeferCFree(t *testing.T) {
+	preamble := strings.Join([]string{
+		`virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))`,
+		`defer C.free(unsafe.Pointer(virtualReturn_CArray))`,
+		`for i := range virtualReturn {`,
+		`	virtualReturn_i_ms := C.struct_miqt_string{}`,
+		`	virtualReturn_i_ms.data = C.CString(virtualReturn[i])`,
+		`	virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))`,
+		`	defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))`,
+		`	virtualReturn_CArray[i] = virtualReturn_i_ms`,
+		`}`,
+	}, "\n")
+
+	got := stripDeferCFree(preamble)
+
+	if strings.Contains(got, "defer C.free(") {
+		t.Fatalf("stripDeferCFree left a defer C.free (use-after-free):\n%s", got)
+	}
+	// must keep everything else (the allocation + string construction)
+	for _, must := range []string{"C.malloc", "C.CString", "for i := range virtualReturn", "virtualReturn_i_ms.len"} {
+		if !strings.Contains(got, must) {
+			t.Fatalf("stripDeferCFree removed non-free content %q:\n%s", must, got)
+		}
+	}
+	// it should have removed exactly the two defer lines
+	if before, after := strings.Count(preamble, "\n"), strings.Count(got, "\n"); before-after != 2 {
+		t.Fatalf("expected 2 lines removed, removed %d", before-after)
+	}
+}

--- a/qt-extras/qwt/gen_qwt_color_map.cpp
+++ b/qt-extras/qwt/gen_qwt_color_map.cpp
@@ -80,6 +80,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<unsigned int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -244,6 +245,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<unsigned int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -420,6 +422,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<unsigned int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt-extras/qwt/gen_qwt_color_map.go
+++ b/qt-extras/qwt/gen_qwt_color_map.go
@@ -183,7 +183,6 @@ func miqt_exec_callback_QwtColorMap_colorTable(self *C.QwtColorMap, cb C.intptr_
 
 	virtualReturn := gofunc((&QwtColorMap{h: self}).callVirtualBase_ColorTable, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.uint)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.uint)(virtualReturn[i])
 	}
@@ -403,7 +402,6 @@ func miqt_exec_callback_QwtLinearColorMap_colorTable(self *C.QwtLinearColorMap, 
 
 	virtualReturn := gofunc((&QwtLinearColorMap{h: self}).callVirtualBase_ColorTable, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.uint)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.uint)(virtualReturn[i])
 	}
@@ -549,7 +547,6 @@ func miqt_exec_callback_QwtAlphaColorMap_colorTable(self *C.QwtAlphaColorMap, cb
 
 	virtualReturn := gofunc((&QwtAlphaColorMap{h: self}).callVirtualBase_ColorTable, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.uint)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.uint)(virtualReturn[i])
 	}

--- a/qt-extras/qwt/gen_qwt_date_scale_draw.cpp
+++ b/qt-extras/qwt/gen_qwt_date_scale_draw.cpp
@@ -85,6 +85,7 @@ public:
 		int sigval2 = static_cast<int>(param2_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QwtDateScaleDraw_dateFormatOfDate(this, handle__dateFormatOfDate, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-extras/qwt/gen_qwt_date_scale_draw.go
+++ b/qt-extras/qwt/gen_qwt_date_scale_draw.go
@@ -244,7 +244,6 @@ func miqt_exec_callback_QwtDateScaleDraw_dateFormatOfDate(self *C.QwtDateScaleDr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt-extras/qwt/gen_qwt_picker_machine.cpp
+++ b/qt-extras/qwt/gen_qwt_picker_machine.cpp
@@ -47,6 +47,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -133,6 +134,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -222,6 +224,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -311,6 +314,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -400,6 +404,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -489,6 +494,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -578,6 +584,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -667,6 +674,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QwtPickerMachine::Command>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt-extras/qwt/gen_qwt_picker_machine.go
+++ b/qt-extras/qwt/gen_qwt_picker_machine.go
@@ -124,7 +124,6 @@ func miqt_exec_callback_QwtPickerMachine_transition(self *C.QwtPickerMachine, cb
 
 	virtualReturn := gofunc(slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -238,7 +237,6 @@ func miqt_exec_callback_QwtPickerTrackerMachine_transition(self *C.QwtPickerTrac
 
 	virtualReturn := gofunc((&QwtPickerTrackerMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -352,7 +350,6 @@ func miqt_exec_callback_QwtPickerClickPointMachine_transition(self *C.QwtPickerC
 
 	virtualReturn := gofunc((&QwtPickerClickPointMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -466,7 +463,6 @@ func miqt_exec_callback_QwtPickerDragPointMachine_transition(self *C.QwtPickerDr
 
 	virtualReturn := gofunc((&QwtPickerDragPointMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -580,7 +576,6 @@ func miqt_exec_callback_QwtPickerClickRectMachine_transition(self *C.QwtPickerCl
 
 	virtualReturn := gofunc((&QwtPickerClickRectMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -694,7 +689,6 @@ func miqt_exec_callback_QwtPickerDragRectMachine_transition(self *C.QwtPickerDra
 
 	virtualReturn := gofunc((&QwtPickerDragRectMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -808,7 +802,6 @@ func miqt_exec_callback_QwtPickerDragLineMachine_transition(self *C.QwtPickerDra
 
 	virtualReturn := gofunc((&QwtPickerDragLineMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}
@@ -922,7 +915,6 @@ func miqt_exec_callback_QwtPickerPolygonMachine_transition(self *C.QwtPickerPoly
 
 	virtualReturn := gofunc((&QwtPickerPolygonMachine{h: self}).callVirtualBase_Transition, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt-restricted-extras/qscintilla/gen_qsciabstractapis.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qsciabstractapis.cpp
@@ -154,6 +154,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qsciabstractapis.go
+++ b/qt-restricted-extras/qscintilla/gen_qsciabstractapis.go
@@ -364,12 +364,10 @@ func miqt_exec_callback_QsciAbstractAPIs_callTips(self *C.QsciAbstractAPIs, cb C
 
 	virtualReturn := gofunc(slotval1, slotval2, slotval3, slotval4)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt-restricted-extras/qscintilla/gen_qsciapis.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qsciapis.cpp
@@ -160,6 +160,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qsciapis.go
+++ b/qt-restricted-extras/qscintilla/gen_qsciapis.go
@@ -564,12 +564,10 @@ func miqt_exec_callback_QsciAPIs_callTips(self *C.QsciAPIs, cb C.intptr_t, conte
 
 	virtualReturn := gofunc((&QsciAPIs{h: self}).callVirtualBase_CallTips, slotval1, slotval2, slotval3, slotval4)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt-restricted-extras/qscintilla/gen_qscilexer.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexer.cpp
@@ -151,6 +151,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -355,6 +360,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexer_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexer.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexer.go
@@ -550,7 +550,6 @@ func miqt_exec_callback_QsciLexer_language(self *C.QsciLexer, cb C.intptr_t) *C.
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -578,7 +577,6 @@ func miqt_exec_callback_QsciLexer_lexer(self *C.QsciLexer, cb C.intptr_t) *C.con
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -631,7 +629,6 @@ func miqt_exec_callback_QsciLexer_autoCompletionFillups(self *C.QsciLexer, cb C.
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -667,12 +664,10 @@ func miqt_exec_callback_QsciLexer_autoCompletionWordSeparators(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -706,7 +701,6 @@ func miqt_exec_callback_QsciLexer_blockEnd(self *C.QsciLexer, cb C.intptr_t, sty
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -762,7 +756,6 @@ func miqt_exec_callback_QsciLexer_blockStart(self *C.QsciLexer, cb C.intptr_t, s
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -793,7 +786,6 @@ func miqt_exec_callback_QsciLexer_blockStartKeyword(self *C.QsciLexer, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -987,7 +979,6 @@ func miqt_exec_callback_QsciLexer_keywords(self *C.QsciLexer, cb C.intptr_t, set
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1038,7 +1029,6 @@ func miqt_exec_callback_QsciLexer_description(self *C.QsciLexer, cb C.intptr_t, 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1288,7 +1278,6 @@ func miqt_exec_callback_QsciLexer_wordCharacters(self *C.QsciLexer, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeravs.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeravs.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerAVS_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeravs.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeravs.go
@@ -379,7 +379,6 @@ func miqt_exec_callback_QsciLexerAVS_language(self *C.QsciLexerAVS, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -407,7 +406,6 @@ func miqt_exec_callback_QsciLexerAVS_lexer(self *C.QsciLexerAVS, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -460,7 +458,6 @@ func miqt_exec_callback_QsciLexerAVS_autoCompletionFillups(self *C.QsciLexerAVS,
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -496,12 +493,10 @@ func miqt_exec_callback_QsciLexerAVS_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -535,7 +530,6 @@ func miqt_exec_callback_QsciLexerAVS_blockEnd(self *C.QsciLexerAVS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -591,7 +585,6 @@ func miqt_exec_callback_QsciLexerAVS_blockStart(self *C.QsciLexerAVS, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -622,7 +615,6 @@ func miqt_exec_callback_QsciLexerAVS_blockStartKeyword(self *C.QsciLexerAVS, cb 
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -816,7 +808,6 @@ func miqt_exec_callback_QsciLexerAVS_keywords(self *C.QsciLexerAVS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -867,7 +858,6 @@ func miqt_exec_callback_QsciLexerAVS_description(self *C.QsciLexerAVS, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1117,7 +1107,6 @@ func miqt_exec_callback_QsciLexerAVS_wordCharacters(self *C.QsciLexerAVS, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerbash.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerbash.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerBash_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerbash.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerbash.go
@@ -388,7 +388,6 @@ func miqt_exec_callback_QsciLexerBash_language(self *C.QsciLexerBash, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -416,7 +415,6 @@ func miqt_exec_callback_QsciLexerBash_lexer(self *C.QsciLexerBash, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -469,7 +467,6 @@ func miqt_exec_callback_QsciLexerBash_autoCompletionFillups(self *C.QsciLexerBas
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -505,12 +502,10 @@ func miqt_exec_callback_QsciLexerBash_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -544,7 +539,6 @@ func miqt_exec_callback_QsciLexerBash_blockEnd(self *C.QsciLexerBash, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -600,7 +594,6 @@ func miqt_exec_callback_QsciLexerBash_blockStart(self *C.QsciLexerBash, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -631,7 +624,6 @@ func miqt_exec_callback_QsciLexerBash_blockStartKeyword(self *C.QsciLexerBash, c
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -825,7 +817,6 @@ func miqt_exec_callback_QsciLexerBash_keywords(self *C.QsciLexerBash, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -876,7 +867,6 @@ func miqt_exec_callback_QsciLexerBash_description(self *C.QsciLexerBash, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1126,7 +1116,6 @@ func miqt_exec_callback_QsciLexerBash_wordCharacters(self *C.QsciLexerBash, cb C
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerbatch.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerbatch.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerBatch_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerbatch.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerbatch.go
@@ -274,7 +274,6 @@ func miqt_exec_callback_QsciLexerBatch_language(self *C.QsciLexerBatch, cb C.int
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -302,7 +301,6 @@ func miqt_exec_callback_QsciLexerBatch_lexer(self *C.QsciLexerBatch, cb C.intptr
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -355,7 +353,6 @@ func miqt_exec_callback_QsciLexerBatch_autoCompletionFillups(self *C.QsciLexerBa
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -391,12 +388,10 @@ func miqt_exec_callback_QsciLexerBatch_autoCompletionWordSeparators(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -430,7 +425,6 @@ func miqt_exec_callback_QsciLexerBatch_blockEnd(self *C.QsciLexerBatch, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -486,7 +480,6 @@ func miqt_exec_callback_QsciLexerBatch_blockStart(self *C.QsciLexerBatch, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -517,7 +510,6 @@ func miqt_exec_callback_QsciLexerBatch_blockStartKeyword(self *C.QsciLexerBatch,
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -711,7 +703,6 @@ func miqt_exec_callback_QsciLexerBatch_keywords(self *C.QsciLexerBatch, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -762,7 +753,6 @@ func miqt_exec_callback_QsciLexerBatch_description(self *C.QsciLexerBatch, cb C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1012,7 +1002,6 @@ func miqt_exec_callback_QsciLexerBatch_wordCharacters(self *C.QsciLexerBatch, cb
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercmake.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercmake.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCMake_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercmake.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercmake.go
@@ -342,7 +342,6 @@ func miqt_exec_callback_QsciLexerCMake_language(self *C.QsciLexerCMake, cb C.int
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -370,7 +369,6 @@ func miqt_exec_callback_QsciLexerCMake_lexer(self *C.QsciLexerCMake, cb C.intptr
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -423,7 +421,6 @@ func miqt_exec_callback_QsciLexerCMake_autoCompletionFillups(self *C.QsciLexerCM
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -459,12 +456,10 @@ func miqt_exec_callback_QsciLexerCMake_autoCompletionWordSeparators(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -498,7 +493,6 @@ func miqt_exec_callback_QsciLexerCMake_blockEnd(self *C.QsciLexerCMake, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -554,7 +548,6 @@ func miqt_exec_callback_QsciLexerCMake_blockStart(self *C.QsciLexerCMake, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -585,7 +578,6 @@ func miqt_exec_callback_QsciLexerCMake_blockStartKeyword(self *C.QsciLexerCMake,
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -779,7 +771,6 @@ func miqt_exec_callback_QsciLexerCMake_keywords(self *C.QsciLexerCMake, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -830,7 +821,6 @@ func miqt_exec_callback_QsciLexerCMake_description(self *C.QsciLexerCMake, cb C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1080,7 +1070,6 @@ func miqt_exec_callback_QsciLexerCMake_wordCharacters(self *C.QsciLexerCMake, cb
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercoffeescript.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercoffeescript.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCoffeeScript_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercoffeescript.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercoffeescript.go
@@ -405,7 +405,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_language(self *C.QsciLexerCoffeeSc
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -433,7 +432,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_lexer(self *C.QsciLexerCoffeeScrip
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -486,7 +484,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_autoCompletionFillups(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -522,12 +519,10 @@ func miqt_exec_callback_QsciLexerCoffeeScript_autoCompletionWordSeparators(self 
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -561,7 +556,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_blockEnd(self *C.QsciLexerCoffeeSc
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -617,7 +611,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_blockStart(self *C.QsciLexerCoffee
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -648,7 +641,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_blockStartKeyword(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -842,7 +834,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_keywords(self *C.QsciLexerCoffeeSc
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -893,7 +884,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_description(self *C.QsciLexerCoffe
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1143,7 +1133,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_wordCharacters(self *C.QsciLexerCo
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercpp.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercpp.cpp
@@ -237,6 +237,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -441,6 +446,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCPP_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercpp.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercpp.go
@@ -629,7 +629,6 @@ func miqt_exec_callback_QsciLexerCPP_language(self *C.QsciLexerCPP, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -657,7 +656,6 @@ func miqt_exec_callback_QsciLexerCPP_lexer(self *C.QsciLexerCPP, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -710,7 +708,6 @@ func miqt_exec_callback_QsciLexerCPP_autoCompletionFillups(self *C.QsciLexerCPP,
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -746,12 +743,10 @@ func miqt_exec_callback_QsciLexerCPP_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -785,7 +780,6 @@ func miqt_exec_callback_QsciLexerCPP_blockEnd(self *C.QsciLexerCPP, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -841,7 +835,6 @@ func miqt_exec_callback_QsciLexerCPP_blockStart(self *C.QsciLexerCPP, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -872,7 +865,6 @@ func miqt_exec_callback_QsciLexerCPP_blockStartKeyword(self *C.QsciLexerCPP, cb 
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1066,7 +1058,6 @@ func miqt_exec_callback_QsciLexerCPP_keywords(self *C.QsciLexerCPP, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1117,7 +1108,6 @@ func miqt_exec_callback_QsciLexerCPP_description(self *C.QsciLexerCPP, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1367,7 +1357,6 @@ func miqt_exec_callback_QsciLexerCPP_wordCharacters(self *C.QsciLexerCPP, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercsharp.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercsharp.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCSharp_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercsharp.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercsharp.go
@@ -413,7 +413,6 @@ func miqt_exec_callback_QsciLexerCSharp_language(self *C.QsciLexerCSharp, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -441,7 +440,6 @@ func miqt_exec_callback_QsciLexerCSharp_lexer(self *C.QsciLexerCSharp, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -494,7 +492,6 @@ func miqt_exec_callback_QsciLexerCSharp_autoCompletionFillups(self *C.QsciLexerC
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -530,12 +527,10 @@ func miqt_exec_callback_QsciLexerCSharp_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -569,7 +564,6 @@ func miqt_exec_callback_QsciLexerCSharp_blockEnd(self *C.QsciLexerCSharp, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -625,7 +619,6 @@ func miqt_exec_callback_QsciLexerCSharp_blockStart(self *C.QsciLexerCSharp, cb C
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -656,7 +649,6 @@ func miqt_exec_callback_QsciLexerCSharp_blockStartKeyword(self *C.QsciLexerCShar
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -850,7 +842,6 @@ func miqt_exec_callback_QsciLexerCSharp_keywords(self *C.QsciLexerCSharp, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -901,7 +892,6 @@ func miqt_exec_callback_QsciLexerCSharp_description(self *C.QsciLexerCSharp, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1151,7 +1141,6 @@ func miqt_exec_callback_QsciLexerCSharp_wordCharacters(self *C.QsciLexerCSharp, 
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercss.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercss.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCSS_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercss.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercss.go
@@ -428,7 +428,6 @@ func miqt_exec_callback_QsciLexerCSS_language(self *C.QsciLexerCSS, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -456,7 +455,6 @@ func miqt_exec_callback_QsciLexerCSS_lexer(self *C.QsciLexerCSS, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -509,7 +507,6 @@ func miqt_exec_callback_QsciLexerCSS_autoCompletionFillups(self *C.QsciLexerCSS,
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -545,12 +542,10 @@ func miqt_exec_callback_QsciLexerCSS_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -584,7 +579,6 @@ func miqt_exec_callback_QsciLexerCSS_blockEnd(self *C.QsciLexerCSS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -640,7 +634,6 @@ func miqt_exec_callback_QsciLexerCSS_blockStart(self *C.QsciLexerCSS, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -671,7 +664,6 @@ func miqt_exec_callback_QsciLexerCSS_blockStartKeyword(self *C.QsciLexerCSS, cb 
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -865,7 +857,6 @@ func miqt_exec_callback_QsciLexerCSS_keywords(self *C.QsciLexerCSS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -916,7 +907,6 @@ func miqt_exec_callback_QsciLexerCSS_description(self *C.QsciLexerCSS, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1166,7 +1156,6 @@ func miqt_exec_callback_QsciLexerCSS_wordCharacters(self *C.QsciLexerCSS, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercustom.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercustom.cpp
@@ -194,6 +194,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -398,6 +403,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCustom_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexercustom.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexercustom.go
@@ -309,7 +309,6 @@ func miqt_exec_callback_QsciLexerCustom_language(self *C.QsciLexerCustom, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -337,7 +336,6 @@ func miqt_exec_callback_QsciLexerCustom_lexer(self *C.QsciLexerCustom, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -390,7 +388,6 @@ func miqt_exec_callback_QsciLexerCustom_autoCompletionFillups(self *C.QsciLexerC
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -426,12 +423,10 @@ func miqt_exec_callback_QsciLexerCustom_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -465,7 +460,6 @@ func miqt_exec_callback_QsciLexerCustom_blockEnd(self *C.QsciLexerCustom, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -521,7 +515,6 @@ func miqt_exec_callback_QsciLexerCustom_blockStart(self *C.QsciLexerCustom, cb C
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -552,7 +545,6 @@ func miqt_exec_callback_QsciLexerCustom_blockStartKeyword(self *C.QsciLexerCusto
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -746,7 +738,6 @@ func miqt_exec_callback_QsciLexerCustom_keywords(self *C.QsciLexerCustom, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -797,7 +788,6 @@ func miqt_exec_callback_QsciLexerCustom_description(self *C.QsciLexerCustom, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -996,7 +986,6 @@ func miqt_exec_callback_QsciLexerCustom_wordCharacters(self *C.QsciLexerCustom, 
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerd.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerd.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerD_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerd.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerd.go
@@ -474,7 +474,6 @@ func miqt_exec_callback_QsciLexerD_language(self *C.QsciLexerD, cb C.intptr_t) *
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -502,7 +501,6 @@ func miqt_exec_callback_QsciLexerD_lexer(self *C.QsciLexerD, cb C.intptr_t) *C.c
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -555,7 +553,6 @@ func miqt_exec_callback_QsciLexerD_autoCompletionFillups(self *C.QsciLexerD, cb 
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -591,12 +588,10 @@ func miqt_exec_callback_QsciLexerD_autoCompletionWordSeparators(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -630,7 +625,6 @@ func miqt_exec_callback_QsciLexerD_blockEnd(self *C.QsciLexerD, cb C.intptr_t, s
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -686,7 +680,6 @@ func miqt_exec_callback_QsciLexerD_blockStart(self *C.QsciLexerD, cb C.intptr_t,
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -717,7 +710,6 @@ func miqt_exec_callback_QsciLexerD_blockStartKeyword(self *C.QsciLexerD, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -911,7 +903,6 @@ func miqt_exec_callback_QsciLexerD_keywords(self *C.QsciLexerD, cb C.intptr_t, s
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -962,7 +953,6 @@ func miqt_exec_callback_QsciLexerD_description(self *C.QsciLexerD, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1212,7 +1202,6 @@ func miqt_exec_callback_QsciLexerD_wordCharacters(self *C.QsciLexerD, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerdiff.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerdiff.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerDiff_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerdiff.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerdiff.go
@@ -253,7 +253,6 @@ func miqt_exec_callback_QsciLexerDiff_language(self *C.QsciLexerDiff, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -281,7 +280,6 @@ func miqt_exec_callback_QsciLexerDiff_lexer(self *C.QsciLexerDiff, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -334,7 +332,6 @@ func miqt_exec_callback_QsciLexerDiff_autoCompletionFillups(self *C.QsciLexerDif
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -370,12 +367,10 @@ func miqt_exec_callback_QsciLexerDiff_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -409,7 +404,6 @@ func miqt_exec_callback_QsciLexerDiff_blockEnd(self *C.QsciLexerDiff, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -465,7 +459,6 @@ func miqt_exec_callback_QsciLexerDiff_blockStart(self *C.QsciLexerDiff, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -496,7 +489,6 @@ func miqt_exec_callback_QsciLexerDiff_blockStartKeyword(self *C.QsciLexerDiff, c
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -690,7 +682,6 @@ func miqt_exec_callback_QsciLexerDiff_keywords(self *C.QsciLexerDiff, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -741,7 +732,6 @@ func miqt_exec_callback_QsciLexerDiff_description(self *C.QsciLexerDiff, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -991,7 +981,6 @@ func miqt_exec_callback_QsciLexerDiff_wordCharacters(self *C.QsciLexerDiff, cb C
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeredifact.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeredifact.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerEDIFACT_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeredifact.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeredifact.go
@@ -245,7 +245,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_language(self *C.QsciLexerEDIFACT, cb C
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -273,7 +272,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_lexer(self *C.QsciLexerEDIFACT, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -326,7 +324,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_autoCompletionFillups(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -362,12 +359,10 @@ func miqt_exec_callback_QsciLexerEDIFACT_autoCompletionWordSeparators(self *C.Qs
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -401,7 +396,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_blockEnd(self *C.QsciLexerEDIFACT, cb C
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -457,7 +451,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_blockStart(self *C.QsciLexerEDIFACT, cb
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -488,7 +481,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_blockStartKeyword(self *C.QsciLexerEDIF
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -682,7 +674,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_keywords(self *C.QsciLexerEDIFACT, cb C
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -733,7 +724,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_description(self *C.QsciLexerEDIFACT, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -983,7 +973,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_wordCharacters(self *C.QsciLexerEDIFACT
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerfortran.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerfortran.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerFortran_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerfortran.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerfortran.go
@@ -285,7 +285,6 @@ func miqt_exec_callback_QsciLexerFortran_language(self *C.QsciLexerFortran, cb C
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -313,7 +312,6 @@ func miqt_exec_callback_QsciLexerFortran_lexer(self *C.QsciLexerFortran, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -366,7 +364,6 @@ func miqt_exec_callback_QsciLexerFortran_autoCompletionFillups(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -402,12 +399,10 @@ func miqt_exec_callback_QsciLexerFortran_autoCompletionWordSeparators(self *C.Qs
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -441,7 +436,6 @@ func miqt_exec_callback_QsciLexerFortran_blockEnd(self *C.QsciLexerFortran, cb C
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -497,7 +491,6 @@ func miqt_exec_callback_QsciLexerFortran_blockStart(self *C.QsciLexerFortran, cb
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -528,7 +521,6 @@ func miqt_exec_callback_QsciLexerFortran_blockStartKeyword(self *C.QsciLexerFort
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -722,7 +714,6 @@ func miqt_exec_callback_QsciLexerFortran_keywords(self *C.QsciLexerFortran, cb C
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -773,7 +764,6 @@ func miqt_exec_callback_QsciLexerFortran_description(self *C.QsciLexerFortran, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1023,7 +1013,6 @@ func miqt_exec_callback_QsciLexerFortran_wordCharacters(self *C.QsciLexerFortran
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerfortran77.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerfortran77.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerFortran77_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerfortran77.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerfortran77.go
@@ -350,7 +350,6 @@ func miqt_exec_callback_QsciLexerFortran77_language(self *C.QsciLexerFortran77, 
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -378,7 +377,6 @@ func miqt_exec_callback_QsciLexerFortran77_lexer(self *C.QsciLexerFortran77, cb 
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -431,7 +429,6 @@ func miqt_exec_callback_QsciLexerFortran77_autoCompletionFillups(self *C.QsciLex
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -467,12 +464,10 @@ func miqt_exec_callback_QsciLexerFortran77_autoCompletionWordSeparators(self *C.
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -506,7 +501,6 @@ func miqt_exec_callback_QsciLexerFortran77_blockEnd(self *C.QsciLexerFortran77, 
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -562,7 +556,6 @@ func miqt_exec_callback_QsciLexerFortran77_blockStart(self *C.QsciLexerFortran77
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -593,7 +586,6 @@ func miqt_exec_callback_QsciLexerFortran77_blockStartKeyword(self *C.QsciLexerFo
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -787,7 +779,6 @@ func miqt_exec_callback_QsciLexerFortran77_keywords(self *C.QsciLexerFortran77, 
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -838,7 +829,6 @@ func miqt_exec_callback_QsciLexerFortran77_description(self *C.QsciLexerFortran7
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1088,7 +1078,6 @@ func miqt_exec_callback_QsciLexerFortran77_wordCharacters(self *C.QsciLexerFortr
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerhtml.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerhtml.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerHTML_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerhtml.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerhtml.go
@@ -551,7 +551,6 @@ func miqt_exec_callback_QsciLexerHTML_language(self *C.QsciLexerHTML, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -579,7 +578,6 @@ func miqt_exec_callback_QsciLexerHTML_lexer(self *C.QsciLexerHTML, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -632,7 +630,6 @@ func miqt_exec_callback_QsciLexerHTML_autoCompletionFillups(self *C.QsciLexerHTM
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -668,12 +665,10 @@ func miqt_exec_callback_QsciLexerHTML_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -707,7 +702,6 @@ func miqt_exec_callback_QsciLexerHTML_blockEnd(self *C.QsciLexerHTML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -763,7 +757,6 @@ func miqt_exec_callback_QsciLexerHTML_blockStart(self *C.QsciLexerHTML, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -794,7 +787,6 @@ func miqt_exec_callback_QsciLexerHTML_blockStartKeyword(self *C.QsciLexerHTML, c
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -988,7 +980,6 @@ func miqt_exec_callback_QsciLexerHTML_keywords(self *C.QsciLexerHTML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1039,7 +1030,6 @@ func miqt_exec_callback_QsciLexerHTML_description(self *C.QsciLexerHTML, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1289,7 +1279,6 @@ func miqt_exec_callback_QsciLexerHTML_wordCharacters(self *C.QsciLexerHTML, cb C
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeridl.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeridl.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerIDL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeridl.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeridl.go
@@ -397,7 +397,6 @@ func miqt_exec_callback_QsciLexerIDL_language(self *C.QsciLexerIDL, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -425,7 +424,6 @@ func miqt_exec_callback_QsciLexerIDL_lexer(self *C.QsciLexerIDL, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -478,7 +476,6 @@ func miqt_exec_callback_QsciLexerIDL_autoCompletionFillups(self *C.QsciLexerIDL,
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -514,12 +511,10 @@ func miqt_exec_callback_QsciLexerIDL_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -553,7 +548,6 @@ func miqt_exec_callback_QsciLexerIDL_blockEnd(self *C.QsciLexerIDL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -609,7 +603,6 @@ func miqt_exec_callback_QsciLexerIDL_blockStart(self *C.QsciLexerIDL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -640,7 +633,6 @@ func miqt_exec_callback_QsciLexerIDL_blockStartKeyword(self *C.QsciLexerIDL, cb 
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -834,7 +826,6 @@ func miqt_exec_callback_QsciLexerIDL_keywords(self *C.QsciLexerIDL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -885,7 +876,6 @@ func miqt_exec_callback_QsciLexerIDL_description(self *C.QsciLexerIDL, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1135,7 +1125,6 @@ func miqt_exec_callback_QsciLexerIDL_wordCharacters(self *C.QsciLexerIDL, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerjava.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerjava.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerJava_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerjava.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerjava.go
@@ -384,7 +384,6 @@ func miqt_exec_callback_QsciLexerJava_language(self *C.QsciLexerJava, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -412,7 +411,6 @@ func miqt_exec_callback_QsciLexerJava_lexer(self *C.QsciLexerJava, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -465,7 +463,6 @@ func miqt_exec_callback_QsciLexerJava_autoCompletionFillups(self *C.QsciLexerJav
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -501,12 +498,10 @@ func miqt_exec_callback_QsciLexerJava_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -540,7 +535,6 @@ func miqt_exec_callback_QsciLexerJava_blockEnd(self *C.QsciLexerJava, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -596,7 +590,6 @@ func miqt_exec_callback_QsciLexerJava_blockStart(self *C.QsciLexerJava, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -627,7 +620,6 @@ func miqt_exec_callback_QsciLexerJava_blockStartKeyword(self *C.QsciLexerJava, c
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -821,7 +813,6 @@ func miqt_exec_callback_QsciLexerJava_keywords(self *C.QsciLexerJava, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -872,7 +863,6 @@ func miqt_exec_callback_QsciLexerJava_description(self *C.QsciLexerJava, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1122,7 +1112,6 @@ func miqt_exec_callback_QsciLexerJava_wordCharacters(self *C.QsciLexerJava, cb C
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerjavascript.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerjavascript.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerJavaScript_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerjavascript.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerjavascript.go
@@ -413,7 +413,6 @@ func miqt_exec_callback_QsciLexerJavaScript_language(self *C.QsciLexerJavaScript
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -441,7 +440,6 @@ func miqt_exec_callback_QsciLexerJavaScript_lexer(self *C.QsciLexerJavaScript, c
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -494,7 +492,6 @@ func miqt_exec_callback_QsciLexerJavaScript_autoCompletionFillups(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -530,12 +527,10 @@ func miqt_exec_callback_QsciLexerJavaScript_autoCompletionWordSeparators(self *C
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -569,7 +564,6 @@ func miqt_exec_callback_QsciLexerJavaScript_blockEnd(self *C.QsciLexerJavaScript
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -625,7 +619,6 @@ func miqt_exec_callback_QsciLexerJavaScript_blockStart(self *C.QsciLexerJavaScri
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -656,7 +649,6 @@ func miqt_exec_callback_QsciLexerJavaScript_blockStartKeyword(self *C.QsciLexerJ
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -850,7 +842,6 @@ func miqt_exec_callback_QsciLexerJavaScript_keywords(self *C.QsciLexerJavaScript
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -901,7 +892,6 @@ func miqt_exec_callback_QsciLexerJavaScript_description(self *C.QsciLexerJavaScr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1151,7 +1141,6 @@ func miqt_exec_callback_QsciLexerJavaScript_wordCharacters(self *C.QsciLexerJava
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerjson.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerjson.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerJSON_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerjson.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerjson.go
@@ -335,7 +335,6 @@ func miqt_exec_callback_QsciLexerJSON_language(self *C.QsciLexerJSON, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -363,7 +362,6 @@ func miqt_exec_callback_QsciLexerJSON_lexer(self *C.QsciLexerJSON, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -416,7 +414,6 @@ func miqt_exec_callback_QsciLexerJSON_autoCompletionFillups(self *C.QsciLexerJSO
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -452,12 +449,10 @@ func miqt_exec_callback_QsciLexerJSON_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -491,7 +486,6 @@ func miqt_exec_callback_QsciLexerJSON_blockEnd(self *C.QsciLexerJSON, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -547,7 +541,6 @@ func miqt_exec_callback_QsciLexerJSON_blockStart(self *C.QsciLexerJSON, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -578,7 +571,6 @@ func miqt_exec_callback_QsciLexerJSON_blockStartKeyword(self *C.QsciLexerJSON, c
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -772,7 +764,6 @@ func miqt_exec_callback_QsciLexerJSON_keywords(self *C.QsciLexerJSON, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -823,7 +814,6 @@ func miqt_exec_callback_QsciLexerJSON_description(self *C.QsciLexerJSON, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1073,7 +1063,6 @@ func miqt_exec_callback_QsciLexerJSON_wordCharacters(self *C.QsciLexerJSON, cb C
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerlua.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerlua.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerLua_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerlua.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerlua.go
@@ -378,7 +378,6 @@ func miqt_exec_callback_QsciLexerLua_language(self *C.QsciLexerLua, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -406,7 +405,6 @@ func miqt_exec_callback_QsciLexerLua_lexer(self *C.QsciLexerLua, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -459,7 +457,6 @@ func miqt_exec_callback_QsciLexerLua_autoCompletionFillups(self *C.QsciLexerLua,
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -495,12 +492,10 @@ func miqt_exec_callback_QsciLexerLua_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -534,7 +529,6 @@ func miqt_exec_callback_QsciLexerLua_blockEnd(self *C.QsciLexerLua, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -590,7 +584,6 @@ func miqt_exec_callback_QsciLexerLua_blockStart(self *C.QsciLexerLua, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -621,7 +614,6 @@ func miqt_exec_callback_QsciLexerLua_blockStartKeyword(self *C.QsciLexerLua, cb 
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -815,7 +807,6 @@ func miqt_exec_callback_QsciLexerLua_keywords(self *C.QsciLexerLua, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -866,7 +857,6 @@ func miqt_exec_callback_QsciLexerLua_description(self *C.QsciLexerLua, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1116,7 +1106,6 @@ func miqt_exec_callback_QsciLexerLua_wordCharacters(self *C.QsciLexerLua, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexermakefile.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexermakefile.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerMakefile_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexermakefile.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexermakefile.go
@@ -264,7 +264,6 @@ func miqt_exec_callback_QsciLexerMakefile_language(self *C.QsciLexerMakefile, cb
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -292,7 +291,6 @@ func miqt_exec_callback_QsciLexerMakefile_lexer(self *C.QsciLexerMakefile, cb C.
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -345,7 +343,6 @@ func miqt_exec_callback_QsciLexerMakefile_autoCompletionFillups(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -381,12 +378,10 @@ func miqt_exec_callback_QsciLexerMakefile_autoCompletionWordSeparators(self *C.Q
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -420,7 +415,6 @@ func miqt_exec_callback_QsciLexerMakefile_blockEnd(self *C.QsciLexerMakefile, cb
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -476,7 +470,6 @@ func miqt_exec_callback_QsciLexerMakefile_blockStart(self *C.QsciLexerMakefile, 
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -507,7 +500,6 @@ func miqt_exec_callback_QsciLexerMakefile_blockStartKeyword(self *C.QsciLexerMak
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -701,7 +693,6 @@ func miqt_exec_callback_QsciLexerMakefile_keywords(self *C.QsciLexerMakefile, cb
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -752,7 +743,6 @@ func miqt_exec_callback_QsciLexerMakefile_description(self *C.QsciLexerMakefile,
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1002,7 +992,6 @@ func miqt_exec_callback_QsciLexerMakefile_wordCharacters(self *C.QsciLexerMakefi
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexermarkdown.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexermarkdown.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerMarkdown_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexermarkdown.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexermarkdown.go
@@ -270,7 +270,6 @@ func miqt_exec_callback_QsciLexerMarkdown_language(self *C.QsciLexerMarkdown, cb
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -298,7 +297,6 @@ func miqt_exec_callback_QsciLexerMarkdown_lexer(self *C.QsciLexerMarkdown, cb C.
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -351,7 +349,6 @@ func miqt_exec_callback_QsciLexerMarkdown_autoCompletionFillups(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -387,12 +384,10 @@ func miqt_exec_callback_QsciLexerMarkdown_autoCompletionWordSeparators(self *C.Q
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -426,7 +421,6 @@ func miqt_exec_callback_QsciLexerMarkdown_blockEnd(self *C.QsciLexerMarkdown, cb
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -482,7 +476,6 @@ func miqt_exec_callback_QsciLexerMarkdown_blockStart(self *C.QsciLexerMarkdown, 
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -513,7 +506,6 @@ func miqt_exec_callback_QsciLexerMarkdown_blockStartKeyword(self *C.QsciLexerMar
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -707,7 +699,6 @@ func miqt_exec_callback_QsciLexerMarkdown_keywords(self *C.QsciLexerMarkdown, cb
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -758,7 +749,6 @@ func miqt_exec_callback_QsciLexerMarkdown_description(self *C.QsciLexerMarkdown,
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1008,7 +998,6 @@ func miqt_exec_callback_QsciLexerMarkdown_wordCharacters(self *C.QsciLexerMarkdo
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexermatlab.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexermatlab.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerMatlab_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexermatlab.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexermatlab.go
@@ -256,7 +256,6 @@ func miqt_exec_callback_QsciLexerMatlab_language(self *C.QsciLexerMatlab, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -284,7 +283,6 @@ func miqt_exec_callback_QsciLexerMatlab_lexer(self *C.QsciLexerMatlab, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -337,7 +335,6 @@ func miqt_exec_callback_QsciLexerMatlab_autoCompletionFillups(self *C.QsciLexerM
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -373,12 +370,10 @@ func miqt_exec_callback_QsciLexerMatlab_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -412,7 +407,6 @@ func miqt_exec_callback_QsciLexerMatlab_blockEnd(self *C.QsciLexerMatlab, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -468,7 +462,6 @@ func miqt_exec_callback_QsciLexerMatlab_blockStart(self *C.QsciLexerMatlab, cb C
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -499,7 +492,6 @@ func miqt_exec_callback_QsciLexerMatlab_blockStartKeyword(self *C.QsciLexerMatla
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -693,7 +685,6 @@ func miqt_exec_callback_QsciLexerMatlab_keywords(self *C.QsciLexerMatlab, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -744,7 +735,6 @@ func miqt_exec_callback_QsciLexerMatlab_description(self *C.QsciLexerMatlab, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -994,7 +984,6 @@ func miqt_exec_callback_QsciLexerMatlab_wordCharacters(self *C.QsciLexerMatlab, 
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeroctave.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeroctave.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerOctave_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeroctave.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeroctave.go
@@ -223,7 +223,6 @@ func miqt_exec_callback_QsciLexerOctave_language(self *C.QsciLexerOctave, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -251,7 +250,6 @@ func miqt_exec_callback_QsciLexerOctave_lexer(self *C.QsciLexerOctave, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -304,7 +302,6 @@ func miqt_exec_callback_QsciLexerOctave_autoCompletionFillups(self *C.QsciLexerO
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -340,12 +337,10 @@ func miqt_exec_callback_QsciLexerOctave_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -379,7 +374,6 @@ func miqt_exec_callback_QsciLexerOctave_blockEnd(self *C.QsciLexerOctave, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -435,7 +429,6 @@ func miqt_exec_callback_QsciLexerOctave_blockStart(self *C.QsciLexerOctave, cb C
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -466,7 +459,6 @@ func miqt_exec_callback_QsciLexerOctave_blockStartKeyword(self *C.QsciLexerOctav
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -660,7 +652,6 @@ func miqt_exec_callback_QsciLexerOctave_keywords(self *C.QsciLexerOctave, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -711,7 +702,6 @@ func miqt_exec_callback_QsciLexerOctave_description(self *C.QsciLexerOctave, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -961,7 +951,6 @@ func miqt_exec_callback_QsciLexerOctave_wordCharacters(self *C.QsciLexerOctave, 
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpascal.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpascal.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPascal_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpascal.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpascal.go
@@ -469,7 +469,6 @@ func miqt_exec_callback_QsciLexerPascal_language(self *C.QsciLexerPascal, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -497,7 +496,6 @@ func miqt_exec_callback_QsciLexerPascal_lexer(self *C.QsciLexerPascal, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -550,7 +548,6 @@ func miqt_exec_callback_QsciLexerPascal_autoCompletionFillups(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -586,12 +583,10 @@ func miqt_exec_callback_QsciLexerPascal_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -625,7 +620,6 @@ func miqt_exec_callback_QsciLexerPascal_blockEnd(self *C.QsciLexerPascal, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -681,7 +675,6 @@ func miqt_exec_callback_QsciLexerPascal_blockStart(self *C.QsciLexerPascal, cb C
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -712,7 +705,6 @@ func miqt_exec_callback_QsciLexerPascal_blockStartKeyword(self *C.QsciLexerPasca
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -906,7 +898,6 @@ func miqt_exec_callback_QsciLexerPascal_keywords(self *C.QsciLexerPascal, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -957,7 +948,6 @@ func miqt_exec_callback_QsciLexerPascal_description(self *C.QsciLexerPascal, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1207,7 +1197,6 @@ func miqt_exec_callback_QsciLexerPascal_wordCharacters(self *C.QsciLexerPascal, 
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerperl.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerperl.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPerl_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerperl.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerperl.go
@@ -472,7 +472,6 @@ func miqt_exec_callback_QsciLexerPerl_language(self *C.QsciLexerPerl, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -500,7 +499,6 @@ func miqt_exec_callback_QsciLexerPerl_lexer(self *C.QsciLexerPerl, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -553,7 +551,6 @@ func miqt_exec_callback_QsciLexerPerl_autoCompletionFillups(self *C.QsciLexerPer
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -589,12 +586,10 @@ func miqt_exec_callback_QsciLexerPerl_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -628,7 +623,6 @@ func miqt_exec_callback_QsciLexerPerl_blockEnd(self *C.QsciLexerPerl, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -684,7 +678,6 @@ func miqt_exec_callback_QsciLexerPerl_blockStart(self *C.QsciLexerPerl, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -715,7 +708,6 @@ func miqt_exec_callback_QsciLexerPerl_blockStartKeyword(self *C.QsciLexerPerl, c
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -909,7 +901,6 @@ func miqt_exec_callback_QsciLexerPerl_keywords(self *C.QsciLexerPerl, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -960,7 +951,6 @@ func miqt_exec_callback_QsciLexerPerl_description(self *C.QsciLexerPerl, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1210,7 +1200,6 @@ func miqt_exec_callback_QsciLexerPerl_wordCharacters(self *C.QsciLexerPerl, cb C
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpo.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpo.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPO_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpo.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpo.go
@@ -365,7 +365,6 @@ func miqt_exec_callback_QsciLexerPO_language(self *C.QsciLexerPO, cb C.intptr_t)
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -393,7 +392,6 @@ func miqt_exec_callback_QsciLexerPO_lexer(self *C.QsciLexerPO, cb C.intptr_t) *C
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -446,7 +444,6 @@ func miqt_exec_callback_QsciLexerPO_autoCompletionFillups(self *C.QsciLexerPO, c
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -482,12 +479,10 @@ func miqt_exec_callback_QsciLexerPO_autoCompletionWordSeparators(self *C.QsciLex
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -521,7 +516,6 @@ func miqt_exec_callback_QsciLexerPO_blockEnd(self *C.QsciLexerPO, cb C.intptr_t,
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -577,7 +571,6 @@ func miqt_exec_callback_QsciLexerPO_blockStart(self *C.QsciLexerPO, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -608,7 +601,6 @@ func miqt_exec_callback_QsciLexerPO_blockStartKeyword(self *C.QsciLexerPO, cb C.
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -802,7 +794,6 @@ func miqt_exec_callback_QsciLexerPO_keywords(self *C.QsciLexerPO, cb C.intptr_t,
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -853,7 +844,6 @@ func miqt_exec_callback_QsciLexerPO_description(self *C.QsciLexerPO, cb C.intptr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1103,7 +1093,6 @@ func miqt_exec_callback_QsciLexerPO_wordCharacters(self *C.QsciLexerPO, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpostscript.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpostscript.cpp
@@ -218,6 +218,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -422,6 +427,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPostScript_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpostscript.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpostscript.go
@@ -449,7 +449,6 @@ func miqt_exec_callback_QsciLexerPostScript_language(self *C.QsciLexerPostScript
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -477,7 +476,6 @@ func miqt_exec_callback_QsciLexerPostScript_lexer(self *C.QsciLexerPostScript, c
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -530,7 +528,6 @@ func miqt_exec_callback_QsciLexerPostScript_autoCompletionFillups(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -566,12 +563,10 @@ func miqt_exec_callback_QsciLexerPostScript_autoCompletionWordSeparators(self *C
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -605,7 +600,6 @@ func miqt_exec_callback_QsciLexerPostScript_blockEnd(self *C.QsciLexerPostScript
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -661,7 +655,6 @@ func miqt_exec_callback_QsciLexerPostScript_blockStart(self *C.QsciLexerPostScri
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -692,7 +685,6 @@ func miqt_exec_callback_QsciLexerPostScript_blockStartKeyword(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -886,7 +878,6 @@ func miqt_exec_callback_QsciLexerPostScript_keywords(self *C.QsciLexerPostScript
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -937,7 +928,6 @@ func miqt_exec_callback_QsciLexerPostScript_description(self *C.QsciLexerPostScr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1187,7 +1177,6 @@ func miqt_exec_callback_QsciLexerPostScript_wordCharacters(self *C.QsciLexerPost
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpov.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpov.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPOV_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpov.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpov.go
@@ -425,7 +425,6 @@ func miqt_exec_callback_QsciLexerPOV_language(self *C.QsciLexerPOV, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -453,7 +452,6 @@ func miqt_exec_callback_QsciLexerPOV_lexer(self *C.QsciLexerPOV, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -506,7 +504,6 @@ func miqt_exec_callback_QsciLexerPOV_autoCompletionFillups(self *C.QsciLexerPOV,
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -542,12 +539,10 @@ func miqt_exec_callback_QsciLexerPOV_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -581,7 +576,6 @@ func miqt_exec_callback_QsciLexerPOV_blockEnd(self *C.QsciLexerPOV, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -637,7 +631,6 @@ func miqt_exec_callback_QsciLexerPOV_blockStart(self *C.QsciLexerPOV, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -668,7 +661,6 @@ func miqt_exec_callback_QsciLexerPOV_blockStartKeyword(self *C.QsciLexerPOV, cb 
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -862,7 +854,6 @@ func miqt_exec_callback_QsciLexerPOV_keywords(self *C.QsciLexerPOV, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -913,7 +904,6 @@ func miqt_exec_callback_QsciLexerPOV_description(self *C.QsciLexerPOV, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1163,7 +1153,6 @@ func miqt_exec_callback_QsciLexerPOV_wordCharacters(self *C.QsciLexerPOV, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerproperties.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerproperties.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerProperties_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerproperties.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerproperties.go
@@ -345,7 +345,6 @@ func miqt_exec_callback_QsciLexerProperties_language(self *C.QsciLexerProperties
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -373,7 +372,6 @@ func miqt_exec_callback_QsciLexerProperties_lexer(self *C.QsciLexerProperties, c
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -426,7 +424,6 @@ func miqt_exec_callback_QsciLexerProperties_autoCompletionFillups(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -462,12 +459,10 @@ func miqt_exec_callback_QsciLexerProperties_autoCompletionWordSeparators(self *C
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -501,7 +496,6 @@ func miqt_exec_callback_QsciLexerProperties_blockEnd(self *C.QsciLexerProperties
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -557,7 +551,6 @@ func miqt_exec_callback_QsciLexerProperties_blockStart(self *C.QsciLexerProperti
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -588,7 +581,6 @@ func miqt_exec_callback_QsciLexerProperties_blockStartKeyword(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -782,7 +774,6 @@ func miqt_exec_callback_QsciLexerProperties_keywords(self *C.QsciLexerProperties
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -833,7 +824,6 @@ func miqt_exec_callback_QsciLexerProperties_description(self *C.QsciLexerPropert
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1083,7 +1073,6 @@ func miqt_exec_callback_QsciLexerProperties_wordCharacters(self *C.QsciLexerProp
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpython.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpython.cpp
@@ -216,6 +216,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -405,6 +410,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPython_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerpython.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerpython.go
@@ -537,7 +537,6 @@ func miqt_exec_callback_QsciLexerPython_language(self *C.QsciLexerPython, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -565,7 +564,6 @@ func miqt_exec_callback_QsciLexerPython_lexer(self *C.QsciLexerPython, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -618,7 +616,6 @@ func miqt_exec_callback_QsciLexerPython_autoCompletionFillups(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -654,12 +651,10 @@ func miqt_exec_callback_QsciLexerPython_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -693,7 +688,6 @@ func miqt_exec_callback_QsciLexerPython_blockEnd(self *C.QsciLexerPython, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -749,7 +743,6 @@ func miqt_exec_callback_QsciLexerPython_blockStart(self *C.QsciLexerPython, cb C
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -780,7 +773,6 @@ func miqt_exec_callback_QsciLexerPython_blockStartKeyword(self *C.QsciLexerPytho
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -949,7 +941,6 @@ func miqt_exec_callback_QsciLexerPython_keywords(self *C.QsciLexerPython, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1000,7 +991,6 @@ func miqt_exec_callback_QsciLexerPython_description(self *C.QsciLexerPython, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1250,7 +1240,6 @@ func miqt_exec_callback_QsciLexerPython_wordCharacters(self *C.QsciLexerPython, 
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerruby.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerruby.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerRuby_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerruby.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerruby.go
@@ -378,7 +378,6 @@ func miqt_exec_callback_QsciLexerRuby_language(self *C.QsciLexerRuby, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -406,7 +405,6 @@ func miqt_exec_callback_QsciLexerRuby_lexer(self *C.QsciLexerRuby, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -459,7 +457,6 @@ func miqt_exec_callback_QsciLexerRuby_autoCompletionFillups(self *C.QsciLexerRub
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -495,12 +492,10 @@ func miqt_exec_callback_QsciLexerRuby_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -534,7 +529,6 @@ func miqt_exec_callback_QsciLexerRuby_blockEnd(self *C.QsciLexerRuby, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -590,7 +584,6 @@ func miqt_exec_callback_QsciLexerRuby_blockStart(self *C.QsciLexerRuby, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -621,7 +614,6 @@ func miqt_exec_callback_QsciLexerRuby_blockStartKeyword(self *C.QsciLexerRuby, c
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -815,7 +807,6 @@ func miqt_exec_callback_QsciLexerRuby_keywords(self *C.QsciLexerRuby, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -866,7 +857,6 @@ func miqt_exec_callback_QsciLexerRuby_description(self *C.QsciLexerRuby, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1116,7 +1106,6 @@ func miqt_exec_callback_QsciLexerRuby_wordCharacters(self *C.QsciLexerRuby, cb C
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerspice.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerspice.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerSpice_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerspice.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerspice.go
@@ -260,7 +260,6 @@ func miqt_exec_callback_QsciLexerSpice_language(self *C.QsciLexerSpice, cb C.int
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -288,7 +287,6 @@ func miqt_exec_callback_QsciLexerSpice_lexer(self *C.QsciLexerSpice, cb C.intptr
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -341,7 +339,6 @@ func miqt_exec_callback_QsciLexerSpice_autoCompletionFillups(self *C.QsciLexerSp
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -377,12 +374,10 @@ func miqt_exec_callback_QsciLexerSpice_autoCompletionWordSeparators(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -416,7 +411,6 @@ func miqt_exec_callback_QsciLexerSpice_blockEnd(self *C.QsciLexerSpice, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -472,7 +466,6 @@ func miqt_exec_callback_QsciLexerSpice_blockStart(self *C.QsciLexerSpice, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -503,7 +496,6 @@ func miqt_exec_callback_QsciLexerSpice_blockStartKeyword(self *C.QsciLexerSpice,
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -697,7 +689,6 @@ func miqt_exec_callback_QsciLexerSpice_keywords(self *C.QsciLexerSpice, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -748,7 +739,6 @@ func miqt_exec_callback_QsciLexerSpice_description(self *C.QsciLexerSpice, cb C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -998,7 +988,6 @@ func miqt_exec_callback_QsciLexerSpice_wordCharacters(self *C.QsciLexerSpice, cb
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexersql.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexersql.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerSQL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexersql.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexersql.go
@@ -465,7 +465,6 @@ func miqt_exec_callback_QsciLexerSQL_language(self *C.QsciLexerSQL, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -493,7 +492,6 @@ func miqt_exec_callback_QsciLexerSQL_lexer(self *C.QsciLexerSQL, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -546,7 +544,6 @@ func miqt_exec_callback_QsciLexerSQL_autoCompletionFillups(self *C.QsciLexerSQL,
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -582,12 +579,10 @@ func miqt_exec_callback_QsciLexerSQL_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -621,7 +616,6 @@ func miqt_exec_callback_QsciLexerSQL_blockEnd(self *C.QsciLexerSQL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -677,7 +671,6 @@ func miqt_exec_callback_QsciLexerSQL_blockStart(self *C.QsciLexerSQL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -708,7 +701,6 @@ func miqt_exec_callback_QsciLexerSQL_blockStartKeyword(self *C.QsciLexerSQL, cb 
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -902,7 +894,6 @@ func miqt_exec_callback_QsciLexerSQL_keywords(self *C.QsciLexerSQL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -953,7 +944,6 @@ func miqt_exec_callback_QsciLexerSQL_description(self *C.QsciLexerSQL, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1203,7 +1193,6 @@ func miqt_exec_callback_QsciLexerSQL_wordCharacters(self *C.QsciLexerSQL, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexertcl.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexertcl.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerTCL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexertcl.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexertcl.go
@@ -331,7 +331,6 @@ func miqt_exec_callback_QsciLexerTCL_language(self *C.QsciLexerTCL, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -359,7 +358,6 @@ func miqt_exec_callback_QsciLexerTCL_lexer(self *C.QsciLexerTCL, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -412,7 +410,6 @@ func miqt_exec_callback_QsciLexerTCL_autoCompletionFillups(self *C.QsciLexerTCL,
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -448,12 +445,10 @@ func miqt_exec_callback_QsciLexerTCL_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -487,7 +482,6 @@ func miqt_exec_callback_QsciLexerTCL_blockEnd(self *C.QsciLexerTCL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -543,7 +537,6 @@ func miqt_exec_callback_QsciLexerTCL_blockStart(self *C.QsciLexerTCL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -574,7 +567,6 @@ func miqt_exec_callback_QsciLexerTCL_blockStartKeyword(self *C.QsciLexerTCL, cb 
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -768,7 +760,6 @@ func miqt_exec_callback_QsciLexerTCL_keywords(self *C.QsciLexerTCL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -819,7 +810,6 @@ func miqt_exec_callback_QsciLexerTCL_description(self *C.QsciLexerTCL, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1069,7 +1059,6 @@ func miqt_exec_callback_QsciLexerTCL_wordCharacters(self *C.QsciLexerTCL, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexertex.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexertex.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerTeX_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexertex.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexertex.go
@@ -324,7 +324,6 @@ func miqt_exec_callback_QsciLexerTeX_language(self *C.QsciLexerTeX, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -352,7 +351,6 @@ func miqt_exec_callback_QsciLexerTeX_lexer(self *C.QsciLexerTeX, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -405,7 +403,6 @@ func miqt_exec_callback_QsciLexerTeX_autoCompletionFillups(self *C.QsciLexerTeX,
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -441,12 +438,10 @@ func miqt_exec_callback_QsciLexerTeX_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -480,7 +475,6 @@ func miqt_exec_callback_QsciLexerTeX_blockEnd(self *C.QsciLexerTeX, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -536,7 +530,6 @@ func miqt_exec_callback_QsciLexerTeX_blockStart(self *C.QsciLexerTeX, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -567,7 +560,6 @@ func miqt_exec_callback_QsciLexerTeX_blockStartKeyword(self *C.QsciLexerTeX, cb 
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -761,7 +753,6 @@ func miqt_exec_callback_QsciLexerTeX_keywords(self *C.QsciLexerTeX, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -812,7 +803,6 @@ func miqt_exec_callback_QsciLexerTeX_description(self *C.QsciLexerTeX, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1062,7 +1052,6 @@ func miqt_exec_callback_QsciLexerTeX_wordCharacters(self *C.QsciLexerTeX, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerverilog.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerverilog.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerVerilog_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerverilog.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerverilog.go
@@ -384,7 +384,6 @@ func miqt_exec_callback_QsciLexerVerilog_language(self *C.QsciLexerVerilog, cb C
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -412,7 +411,6 @@ func miqt_exec_callback_QsciLexerVerilog_lexer(self *C.QsciLexerVerilog, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -465,7 +463,6 @@ func miqt_exec_callback_QsciLexerVerilog_autoCompletionFillups(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -501,12 +498,10 @@ func miqt_exec_callback_QsciLexerVerilog_autoCompletionWordSeparators(self *C.Qs
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -540,7 +535,6 @@ func miqt_exec_callback_QsciLexerVerilog_blockEnd(self *C.QsciLexerVerilog, cb C
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -596,7 +590,6 @@ func miqt_exec_callback_QsciLexerVerilog_blockStart(self *C.QsciLexerVerilog, cb
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -627,7 +620,6 @@ func miqt_exec_callback_QsciLexerVerilog_blockStartKeyword(self *C.QsciLexerVeri
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -821,7 +813,6 @@ func miqt_exec_callback_QsciLexerVerilog_keywords(self *C.QsciLexerVerilog, cb C
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -872,7 +863,6 @@ func miqt_exec_callback_QsciLexerVerilog_description(self *C.QsciLexerVerilog, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1122,7 +1112,6 @@ func miqt_exec_callback_QsciLexerVerilog_wordCharacters(self *C.QsciLexerVerilog
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexervhdl.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexervhdl.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerVHDL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexervhdl.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexervhdl.go
@@ -487,7 +487,6 @@ func miqt_exec_callback_QsciLexerVHDL_language(self *C.QsciLexerVHDL, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -515,7 +514,6 @@ func miqt_exec_callback_QsciLexerVHDL_lexer(self *C.QsciLexerVHDL, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -568,7 +566,6 @@ func miqt_exec_callback_QsciLexerVHDL_autoCompletionFillups(self *C.QsciLexerVHD
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -604,12 +601,10 @@ func miqt_exec_callback_QsciLexerVHDL_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -643,7 +638,6 @@ func miqt_exec_callback_QsciLexerVHDL_blockEnd(self *C.QsciLexerVHDL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -699,7 +693,6 @@ func miqt_exec_callback_QsciLexerVHDL_blockStart(self *C.QsciLexerVHDL, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -730,7 +723,6 @@ func miqt_exec_callback_QsciLexerVHDL_blockStartKeyword(self *C.QsciLexerVHDL, c
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -924,7 +916,6 @@ func miqt_exec_callback_QsciLexerVHDL_keywords(self *C.QsciLexerVHDL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -975,7 +966,6 @@ func miqt_exec_callback_QsciLexerVHDL_description(self *C.QsciLexerVHDL, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1225,7 +1215,6 @@ func miqt_exec_callback_QsciLexerVHDL_wordCharacters(self *C.QsciLexerVHDL, cb C
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerxml.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerxml.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerXML_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexerxml.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexerxml.go
@@ -371,7 +371,6 @@ func miqt_exec_callback_QsciLexerXML_language(self *C.QsciLexerXML, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -399,7 +398,6 @@ func miqt_exec_callback_QsciLexerXML_lexer(self *C.QsciLexerXML, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -452,7 +450,6 @@ func miqt_exec_callback_QsciLexerXML_autoCompletionFillups(self *C.QsciLexerXML,
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -488,12 +485,10 @@ func miqt_exec_callback_QsciLexerXML_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -527,7 +522,6 @@ func miqt_exec_callback_QsciLexerXML_blockEnd(self *C.QsciLexerXML, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -583,7 +577,6 @@ func miqt_exec_callback_QsciLexerXML_blockStart(self *C.QsciLexerXML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -614,7 +607,6 @@ func miqt_exec_callback_QsciLexerXML_blockStartKeyword(self *C.QsciLexerXML, cb 
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -808,7 +800,6 @@ func miqt_exec_callback_QsciLexerXML_keywords(self *C.QsciLexerXML, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -859,7 +850,6 @@ func miqt_exec_callback_QsciLexerXML_description(self *C.QsciLexerXML, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1109,7 +1099,6 @@ func miqt_exec_callback_QsciLexerXML_wordCharacters(self *C.QsciLexerXML, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeryaml.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeryaml.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerYAML_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qscilexeryaml.go
+++ b/qt-restricted-extras/qscintilla/gen_qscilexeryaml.go
@@ -341,7 +341,6 @@ func miqt_exec_callback_QsciLexerYAML_language(self *C.QsciLexerYAML, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -369,7 +368,6 @@ func miqt_exec_callback_QsciLexerYAML_lexer(self *C.QsciLexerYAML, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -422,7 +420,6 @@ func miqt_exec_callback_QsciLexerYAML_autoCompletionFillups(self *C.QsciLexerYAM
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -458,12 +455,10 @@ func miqt_exec_callback_QsciLexerYAML_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -497,7 +492,6 @@ func miqt_exec_callback_QsciLexerYAML_blockEnd(self *C.QsciLexerYAML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -553,7 +547,6 @@ func miqt_exec_callback_QsciLexerYAML_blockStart(self *C.QsciLexerYAML, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -584,7 +577,6 @@ func miqt_exec_callback_QsciLexerYAML_blockStartKeyword(self *C.QsciLexerYAML, c
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -778,7 +770,6 @@ func miqt_exec_callback_QsciLexerYAML_keywords(self *C.QsciLexerYAML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -829,7 +820,6 @@ func miqt_exec_callback_QsciLexerYAML_description(self *C.QsciLexerYAML, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1079,7 +1069,6 @@ func miqt_exec_callback_QsciLexerYAML_wordCharacters(self *C.QsciLexerYAML, cb C
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla/gen_qsciscintilla.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qsciscintilla.cpp
@@ -233,6 +233,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1829,6 +1834,7 @@ public:
 		bool* sigval2 = &rectangular;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciScintilla_fromMimeData(this, handle__fromMimeData, sigval1, sigval2);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt-restricted-extras/qscintilla/gen_qsciscintilla.go
+++ b/qt-restricted-extras/qscintilla/gen_qsciscintilla.go
@@ -2107,12 +2107,10 @@ func miqt_exec_callback_QsciScintilla_apiContext(self *C.QsciScintilla, cb C.int
 
 	virtualReturn := gofunc((&QsciScintilla{h: self}).callVirtualBase_ApiContext, slotval1, slotval2, slotval3)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt-restricted-extras/qscintilla/gen_qsciscintillabase.cpp
+++ b/qt-restricted-extras/qscintilla/gen_qsciscintillabase.cpp
@@ -182,6 +182,7 @@ public:
 		bool* sigval2 = &rectangular;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciScintillaBase_fromMimeData(this, handle__fromMimeData, sigval1, sigval2);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qsciabstractapis.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qsciabstractapis.cpp
@@ -154,6 +154,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qsciabstractapis.go
+++ b/qt-restricted-extras/qscintilla6/gen_qsciabstractapis.go
@@ -333,12 +333,10 @@ func miqt_exec_callback_QsciAbstractAPIs_callTips(self *C.QsciAbstractAPIs, cb C
 
 	virtualReturn := gofunc(slotval1, slotval2, slotval3, slotval4)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt-restricted-extras/qscintilla6/gen_qsciapis.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qsciapis.cpp
@@ -160,6 +160,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qsciapis.go
+++ b/qt-restricted-extras/qscintilla6/gen_qsciapis.go
@@ -533,12 +533,10 @@ func miqt_exec_callback_QsciAPIs_callTips(self *C.QsciAPIs, cb C.intptr_t, conte
 
 	virtualReturn := gofunc((&QsciAPIs{h: self}).callVirtualBase_CallTips, slotval1, slotval2, slotval3, slotval4)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt-restricted-extras/qscintilla6/gen_qscilexer.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexer.cpp
@@ -151,6 +151,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -355,6 +360,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexer_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexer.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexer.go
@@ -519,7 +519,6 @@ func miqt_exec_callback_QsciLexer_language(self *C.QsciLexer, cb C.intptr_t) *C.
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -547,7 +546,6 @@ func miqt_exec_callback_QsciLexer_lexer(self *C.QsciLexer, cb C.intptr_t) *C.con
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -600,7 +598,6 @@ func miqt_exec_callback_QsciLexer_autoCompletionFillups(self *C.QsciLexer, cb C.
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -636,12 +633,10 @@ func miqt_exec_callback_QsciLexer_autoCompletionWordSeparators(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -675,7 +670,6 @@ func miqt_exec_callback_QsciLexer_blockEnd(self *C.QsciLexer, cb C.intptr_t, sty
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -731,7 +725,6 @@ func miqt_exec_callback_QsciLexer_blockStart(self *C.QsciLexer, cb C.intptr_t, s
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -762,7 +755,6 @@ func miqt_exec_callback_QsciLexer_blockStartKeyword(self *C.QsciLexer, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -956,7 +948,6 @@ func miqt_exec_callback_QsciLexer_keywords(self *C.QsciLexer, cb C.intptr_t, set
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1007,7 +998,6 @@ func miqt_exec_callback_QsciLexer_description(self *C.QsciLexer, cb C.intptr_t, 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1257,7 +1247,6 @@ func miqt_exec_callback_QsciLexer_wordCharacters(self *C.QsciLexer, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexer{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeravs.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeravs.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerAVS_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeravs.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeravs.go
@@ -348,7 +348,6 @@ func miqt_exec_callback_QsciLexerAVS_language(self *C.QsciLexerAVS, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -376,7 +375,6 @@ func miqt_exec_callback_QsciLexerAVS_lexer(self *C.QsciLexerAVS, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -429,7 +427,6 @@ func miqt_exec_callback_QsciLexerAVS_autoCompletionFillups(self *C.QsciLexerAVS,
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -465,12 +462,10 @@ func miqt_exec_callback_QsciLexerAVS_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -504,7 +499,6 @@ func miqt_exec_callback_QsciLexerAVS_blockEnd(self *C.QsciLexerAVS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -560,7 +554,6 @@ func miqt_exec_callback_QsciLexerAVS_blockStart(self *C.QsciLexerAVS, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -591,7 +584,6 @@ func miqt_exec_callback_QsciLexerAVS_blockStartKeyword(self *C.QsciLexerAVS, cb 
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -785,7 +777,6 @@ func miqt_exec_callback_QsciLexerAVS_keywords(self *C.QsciLexerAVS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -836,7 +827,6 @@ func miqt_exec_callback_QsciLexerAVS_description(self *C.QsciLexerAVS, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1086,7 +1076,6 @@ func miqt_exec_callback_QsciLexerAVS_wordCharacters(self *C.QsciLexerAVS, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerAVS{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerbash.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerbash.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerBash_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerbash.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerbash.go
@@ -357,7 +357,6 @@ func miqt_exec_callback_QsciLexerBash_language(self *C.QsciLexerBash, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -385,7 +384,6 @@ func miqt_exec_callback_QsciLexerBash_lexer(self *C.QsciLexerBash, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -438,7 +436,6 @@ func miqt_exec_callback_QsciLexerBash_autoCompletionFillups(self *C.QsciLexerBas
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -474,12 +471,10 @@ func miqt_exec_callback_QsciLexerBash_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -513,7 +508,6 @@ func miqt_exec_callback_QsciLexerBash_blockEnd(self *C.QsciLexerBash, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -569,7 +563,6 @@ func miqt_exec_callback_QsciLexerBash_blockStart(self *C.QsciLexerBash, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -600,7 +593,6 @@ func miqt_exec_callback_QsciLexerBash_blockStartKeyword(self *C.QsciLexerBash, c
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -794,7 +786,6 @@ func miqt_exec_callback_QsciLexerBash_keywords(self *C.QsciLexerBash, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -845,7 +836,6 @@ func miqt_exec_callback_QsciLexerBash_description(self *C.QsciLexerBash, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1095,7 +1085,6 @@ func miqt_exec_callback_QsciLexerBash_wordCharacters(self *C.QsciLexerBash, cb C
 
 	virtualReturn := gofunc((&QsciLexerBash{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerbatch.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerbatch.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerBatch_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerbatch.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerbatch.go
@@ -243,7 +243,6 @@ func miqt_exec_callback_QsciLexerBatch_language(self *C.QsciLexerBatch, cb C.int
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -271,7 +270,6 @@ func miqt_exec_callback_QsciLexerBatch_lexer(self *C.QsciLexerBatch, cb C.intptr
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -324,7 +322,6 @@ func miqt_exec_callback_QsciLexerBatch_autoCompletionFillups(self *C.QsciLexerBa
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -360,12 +357,10 @@ func miqt_exec_callback_QsciLexerBatch_autoCompletionWordSeparators(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -399,7 +394,6 @@ func miqt_exec_callback_QsciLexerBatch_blockEnd(self *C.QsciLexerBatch, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -455,7 +449,6 @@ func miqt_exec_callback_QsciLexerBatch_blockStart(self *C.QsciLexerBatch, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -486,7 +479,6 @@ func miqt_exec_callback_QsciLexerBatch_blockStartKeyword(self *C.QsciLexerBatch,
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -680,7 +672,6 @@ func miqt_exec_callback_QsciLexerBatch_keywords(self *C.QsciLexerBatch, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -731,7 +722,6 @@ func miqt_exec_callback_QsciLexerBatch_description(self *C.QsciLexerBatch, cb C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -981,7 +971,6 @@ func miqt_exec_callback_QsciLexerBatch_wordCharacters(self *C.QsciLexerBatch, cb
 
 	virtualReturn := gofunc((&QsciLexerBatch{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercmake.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercmake.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCMake_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercmake.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercmake.go
@@ -311,7 +311,6 @@ func miqt_exec_callback_QsciLexerCMake_language(self *C.QsciLexerCMake, cb C.int
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -339,7 +338,6 @@ func miqt_exec_callback_QsciLexerCMake_lexer(self *C.QsciLexerCMake, cb C.intptr
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -392,7 +390,6 @@ func miqt_exec_callback_QsciLexerCMake_autoCompletionFillups(self *C.QsciLexerCM
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -428,12 +425,10 @@ func miqt_exec_callback_QsciLexerCMake_autoCompletionWordSeparators(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -467,7 +462,6 @@ func miqt_exec_callback_QsciLexerCMake_blockEnd(self *C.QsciLexerCMake, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -523,7 +517,6 @@ func miqt_exec_callback_QsciLexerCMake_blockStart(self *C.QsciLexerCMake, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -554,7 +547,6 @@ func miqt_exec_callback_QsciLexerCMake_blockStartKeyword(self *C.QsciLexerCMake,
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -748,7 +740,6 @@ func miqt_exec_callback_QsciLexerCMake_keywords(self *C.QsciLexerCMake, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -799,7 +790,6 @@ func miqt_exec_callback_QsciLexerCMake_description(self *C.QsciLexerCMake, cb C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1049,7 +1039,6 @@ func miqt_exec_callback_QsciLexerCMake_wordCharacters(self *C.QsciLexerCMake, cb
 
 	virtualReturn := gofunc((&QsciLexerCMake{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercoffeescript.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercoffeescript.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCoffeeScript_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercoffeescript.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercoffeescript.go
@@ -374,7 +374,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_language(self *C.QsciLexerCoffeeSc
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -402,7 +401,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_lexer(self *C.QsciLexerCoffeeScrip
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -455,7 +453,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_autoCompletionFillups(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -491,12 +488,10 @@ func miqt_exec_callback_QsciLexerCoffeeScript_autoCompletionWordSeparators(self 
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -530,7 +525,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_blockEnd(self *C.QsciLexerCoffeeSc
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -586,7 +580,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_blockStart(self *C.QsciLexerCoffee
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -617,7 +610,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_blockStartKeyword(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -811,7 +803,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_keywords(self *C.QsciLexerCoffeeSc
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -862,7 +853,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_description(self *C.QsciLexerCoffe
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1112,7 +1102,6 @@ func miqt_exec_callback_QsciLexerCoffeeScript_wordCharacters(self *C.QsciLexerCo
 
 	virtualReturn := gofunc((&QsciLexerCoffeeScript{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercpp.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercpp.cpp
@@ -237,6 +237,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -441,6 +446,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCPP_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercpp.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercpp.go
@@ -598,7 +598,6 @@ func miqt_exec_callback_QsciLexerCPP_language(self *C.QsciLexerCPP, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -626,7 +625,6 @@ func miqt_exec_callback_QsciLexerCPP_lexer(self *C.QsciLexerCPP, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -679,7 +677,6 @@ func miqt_exec_callback_QsciLexerCPP_autoCompletionFillups(self *C.QsciLexerCPP,
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -715,12 +712,10 @@ func miqt_exec_callback_QsciLexerCPP_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -754,7 +749,6 @@ func miqt_exec_callback_QsciLexerCPP_blockEnd(self *C.QsciLexerCPP, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -810,7 +804,6 @@ func miqt_exec_callback_QsciLexerCPP_blockStart(self *C.QsciLexerCPP, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -841,7 +834,6 @@ func miqt_exec_callback_QsciLexerCPP_blockStartKeyword(self *C.QsciLexerCPP, cb 
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1035,7 +1027,6 @@ func miqt_exec_callback_QsciLexerCPP_keywords(self *C.QsciLexerCPP, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1086,7 +1077,6 @@ func miqt_exec_callback_QsciLexerCPP_description(self *C.QsciLexerCPP, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1336,7 +1326,6 @@ func miqt_exec_callback_QsciLexerCPP_wordCharacters(self *C.QsciLexerCPP, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCPP{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercsharp.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercsharp.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCSharp_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercsharp.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercsharp.go
@@ -382,7 +382,6 @@ func miqt_exec_callback_QsciLexerCSharp_language(self *C.QsciLexerCSharp, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -410,7 +409,6 @@ func miqt_exec_callback_QsciLexerCSharp_lexer(self *C.QsciLexerCSharp, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -463,7 +461,6 @@ func miqt_exec_callback_QsciLexerCSharp_autoCompletionFillups(self *C.QsciLexerC
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -499,12 +496,10 @@ func miqt_exec_callback_QsciLexerCSharp_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -538,7 +533,6 @@ func miqt_exec_callback_QsciLexerCSharp_blockEnd(self *C.QsciLexerCSharp, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -594,7 +588,6 @@ func miqt_exec_callback_QsciLexerCSharp_blockStart(self *C.QsciLexerCSharp, cb C
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -625,7 +618,6 @@ func miqt_exec_callback_QsciLexerCSharp_blockStartKeyword(self *C.QsciLexerCShar
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -819,7 +811,6 @@ func miqt_exec_callback_QsciLexerCSharp_keywords(self *C.QsciLexerCSharp, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -870,7 +861,6 @@ func miqt_exec_callback_QsciLexerCSharp_description(self *C.QsciLexerCSharp, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1120,7 +1110,6 @@ func miqt_exec_callback_QsciLexerCSharp_wordCharacters(self *C.QsciLexerCSharp, 
 
 	virtualReturn := gofunc((&QsciLexerCSharp{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercss.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercss.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCSS_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercss.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercss.go
@@ -397,7 +397,6 @@ func miqt_exec_callback_QsciLexerCSS_language(self *C.QsciLexerCSS, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -425,7 +424,6 @@ func miqt_exec_callback_QsciLexerCSS_lexer(self *C.QsciLexerCSS, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -478,7 +476,6 @@ func miqt_exec_callback_QsciLexerCSS_autoCompletionFillups(self *C.QsciLexerCSS,
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -514,12 +511,10 @@ func miqt_exec_callback_QsciLexerCSS_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -553,7 +548,6 @@ func miqt_exec_callback_QsciLexerCSS_blockEnd(self *C.QsciLexerCSS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -609,7 +603,6 @@ func miqt_exec_callback_QsciLexerCSS_blockStart(self *C.QsciLexerCSS, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -640,7 +633,6 @@ func miqt_exec_callback_QsciLexerCSS_blockStartKeyword(self *C.QsciLexerCSS, cb 
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -834,7 +826,6 @@ func miqt_exec_callback_QsciLexerCSS_keywords(self *C.QsciLexerCSS, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -885,7 +876,6 @@ func miqt_exec_callback_QsciLexerCSS_description(self *C.QsciLexerCSS, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1135,7 +1125,6 @@ func miqt_exec_callback_QsciLexerCSS_wordCharacters(self *C.QsciLexerCSS, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCSS{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercustom.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercustom.cpp
@@ -194,6 +194,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -398,6 +403,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerCustom_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexercustom.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexercustom.go
@@ -278,7 +278,6 @@ func miqt_exec_callback_QsciLexerCustom_language(self *C.QsciLexerCustom, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -306,7 +305,6 @@ func miqt_exec_callback_QsciLexerCustom_lexer(self *C.QsciLexerCustom, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -359,7 +357,6 @@ func miqt_exec_callback_QsciLexerCustom_autoCompletionFillups(self *C.QsciLexerC
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -395,12 +392,10 @@ func miqt_exec_callback_QsciLexerCustom_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -434,7 +429,6 @@ func miqt_exec_callback_QsciLexerCustom_blockEnd(self *C.QsciLexerCustom, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -490,7 +484,6 @@ func miqt_exec_callback_QsciLexerCustom_blockStart(self *C.QsciLexerCustom, cb C
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -521,7 +514,6 @@ func miqt_exec_callback_QsciLexerCustom_blockStartKeyword(self *C.QsciLexerCusto
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -715,7 +707,6 @@ func miqt_exec_callback_QsciLexerCustom_keywords(self *C.QsciLexerCustom, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -766,7 +757,6 @@ func miqt_exec_callback_QsciLexerCustom_description(self *C.QsciLexerCustom, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -965,7 +955,6 @@ func miqt_exec_callback_QsciLexerCustom_wordCharacters(self *C.QsciLexerCustom, 
 
 	virtualReturn := gofunc((&QsciLexerCustom{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerd.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerd.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerD_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerd.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerd.go
@@ -443,7 +443,6 @@ func miqt_exec_callback_QsciLexerD_language(self *C.QsciLexerD, cb C.intptr_t) *
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -471,7 +470,6 @@ func miqt_exec_callback_QsciLexerD_lexer(self *C.QsciLexerD, cb C.intptr_t) *C.c
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -524,7 +522,6 @@ func miqt_exec_callback_QsciLexerD_autoCompletionFillups(self *C.QsciLexerD, cb 
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -560,12 +557,10 @@ func miqt_exec_callback_QsciLexerD_autoCompletionWordSeparators(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -599,7 +594,6 @@ func miqt_exec_callback_QsciLexerD_blockEnd(self *C.QsciLexerD, cb C.intptr_t, s
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -655,7 +649,6 @@ func miqt_exec_callback_QsciLexerD_blockStart(self *C.QsciLexerD, cb C.intptr_t,
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -686,7 +679,6 @@ func miqt_exec_callback_QsciLexerD_blockStartKeyword(self *C.QsciLexerD, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -880,7 +872,6 @@ func miqt_exec_callback_QsciLexerD_keywords(self *C.QsciLexerD, cb C.intptr_t, s
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -931,7 +922,6 @@ func miqt_exec_callback_QsciLexerD_description(self *C.QsciLexerD, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1181,7 +1171,6 @@ func miqt_exec_callback_QsciLexerD_wordCharacters(self *C.QsciLexerD, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerD{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerdiff.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerdiff.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerDiff_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerdiff.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerdiff.go
@@ -222,7 +222,6 @@ func miqt_exec_callback_QsciLexerDiff_language(self *C.QsciLexerDiff, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -250,7 +249,6 @@ func miqt_exec_callback_QsciLexerDiff_lexer(self *C.QsciLexerDiff, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -303,7 +301,6 @@ func miqt_exec_callback_QsciLexerDiff_autoCompletionFillups(self *C.QsciLexerDif
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -339,12 +336,10 @@ func miqt_exec_callback_QsciLexerDiff_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -378,7 +373,6 @@ func miqt_exec_callback_QsciLexerDiff_blockEnd(self *C.QsciLexerDiff, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -434,7 +428,6 @@ func miqt_exec_callback_QsciLexerDiff_blockStart(self *C.QsciLexerDiff, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -465,7 +458,6 @@ func miqt_exec_callback_QsciLexerDiff_blockStartKeyword(self *C.QsciLexerDiff, c
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -659,7 +651,6 @@ func miqt_exec_callback_QsciLexerDiff_keywords(self *C.QsciLexerDiff, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -710,7 +701,6 @@ func miqt_exec_callback_QsciLexerDiff_description(self *C.QsciLexerDiff, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -960,7 +950,6 @@ func miqt_exec_callback_QsciLexerDiff_wordCharacters(self *C.QsciLexerDiff, cb C
 
 	virtualReturn := gofunc((&QsciLexerDiff{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeredifact.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeredifact.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerEDIFACT_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeredifact.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeredifact.go
@@ -214,7 +214,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_language(self *C.QsciLexerEDIFACT, cb C
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -242,7 +241,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_lexer(self *C.QsciLexerEDIFACT, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -295,7 +293,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_autoCompletionFillups(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -331,12 +328,10 @@ func miqt_exec_callback_QsciLexerEDIFACT_autoCompletionWordSeparators(self *C.Qs
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -370,7 +365,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_blockEnd(self *C.QsciLexerEDIFACT, cb C
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -426,7 +420,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_blockStart(self *C.QsciLexerEDIFACT, cb
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -457,7 +450,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_blockStartKeyword(self *C.QsciLexerEDIF
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -651,7 +643,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_keywords(self *C.QsciLexerEDIFACT, cb C
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -702,7 +693,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_description(self *C.QsciLexerEDIFACT, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -952,7 +942,6 @@ func miqt_exec_callback_QsciLexerEDIFACT_wordCharacters(self *C.QsciLexerEDIFACT
 
 	virtualReturn := gofunc((&QsciLexerEDIFACT{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerfortran.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerfortran.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerFortran_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerfortran.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerfortran.go
@@ -254,7 +254,6 @@ func miqt_exec_callback_QsciLexerFortran_language(self *C.QsciLexerFortran, cb C
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -282,7 +281,6 @@ func miqt_exec_callback_QsciLexerFortran_lexer(self *C.QsciLexerFortran, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -335,7 +333,6 @@ func miqt_exec_callback_QsciLexerFortran_autoCompletionFillups(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -371,12 +368,10 @@ func miqt_exec_callback_QsciLexerFortran_autoCompletionWordSeparators(self *C.Qs
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -410,7 +405,6 @@ func miqt_exec_callback_QsciLexerFortran_blockEnd(self *C.QsciLexerFortran, cb C
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -466,7 +460,6 @@ func miqt_exec_callback_QsciLexerFortran_blockStart(self *C.QsciLexerFortran, cb
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -497,7 +490,6 @@ func miqt_exec_callback_QsciLexerFortran_blockStartKeyword(self *C.QsciLexerFort
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -691,7 +683,6 @@ func miqt_exec_callback_QsciLexerFortran_keywords(self *C.QsciLexerFortran, cb C
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -742,7 +733,6 @@ func miqt_exec_callback_QsciLexerFortran_description(self *C.QsciLexerFortran, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -992,7 +982,6 @@ func miqt_exec_callback_QsciLexerFortran_wordCharacters(self *C.QsciLexerFortran
 
 	virtualReturn := gofunc((&QsciLexerFortran{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerfortran77.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerfortran77.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerFortran77_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerfortran77.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerfortran77.go
@@ -319,7 +319,6 @@ func miqt_exec_callback_QsciLexerFortran77_language(self *C.QsciLexerFortran77, 
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -347,7 +346,6 @@ func miqt_exec_callback_QsciLexerFortran77_lexer(self *C.QsciLexerFortran77, cb 
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -400,7 +398,6 @@ func miqt_exec_callback_QsciLexerFortran77_autoCompletionFillups(self *C.QsciLex
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -436,12 +433,10 @@ func miqt_exec_callback_QsciLexerFortran77_autoCompletionWordSeparators(self *C.
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -475,7 +470,6 @@ func miqt_exec_callback_QsciLexerFortran77_blockEnd(self *C.QsciLexerFortran77, 
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -531,7 +525,6 @@ func miqt_exec_callback_QsciLexerFortran77_blockStart(self *C.QsciLexerFortran77
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -562,7 +555,6 @@ func miqt_exec_callback_QsciLexerFortran77_blockStartKeyword(self *C.QsciLexerFo
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -756,7 +748,6 @@ func miqt_exec_callback_QsciLexerFortran77_keywords(self *C.QsciLexerFortran77, 
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -807,7 +798,6 @@ func miqt_exec_callback_QsciLexerFortran77_description(self *C.QsciLexerFortran7
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1057,7 +1047,6 @@ func miqt_exec_callback_QsciLexerFortran77_wordCharacters(self *C.QsciLexerFortr
 
 	virtualReturn := gofunc((&QsciLexerFortran77{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerhtml.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerhtml.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerHTML_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerhtml.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerhtml.go
@@ -520,7 +520,6 @@ func miqt_exec_callback_QsciLexerHTML_language(self *C.QsciLexerHTML, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -548,7 +547,6 @@ func miqt_exec_callback_QsciLexerHTML_lexer(self *C.QsciLexerHTML, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -601,7 +599,6 @@ func miqt_exec_callback_QsciLexerHTML_autoCompletionFillups(self *C.QsciLexerHTM
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -637,12 +634,10 @@ func miqt_exec_callback_QsciLexerHTML_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -676,7 +671,6 @@ func miqt_exec_callback_QsciLexerHTML_blockEnd(self *C.QsciLexerHTML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -732,7 +726,6 @@ func miqt_exec_callback_QsciLexerHTML_blockStart(self *C.QsciLexerHTML, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -763,7 +756,6 @@ func miqt_exec_callback_QsciLexerHTML_blockStartKeyword(self *C.QsciLexerHTML, c
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -957,7 +949,6 @@ func miqt_exec_callback_QsciLexerHTML_keywords(self *C.QsciLexerHTML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -1008,7 +999,6 @@ func miqt_exec_callback_QsciLexerHTML_description(self *C.QsciLexerHTML, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1258,7 +1248,6 @@ func miqt_exec_callback_QsciLexerHTML_wordCharacters(self *C.QsciLexerHTML, cb C
 
 	virtualReturn := gofunc((&QsciLexerHTML{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeridl.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeridl.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerIDL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeridl.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeridl.go
@@ -366,7 +366,6 @@ func miqt_exec_callback_QsciLexerIDL_language(self *C.QsciLexerIDL, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -394,7 +393,6 @@ func miqt_exec_callback_QsciLexerIDL_lexer(self *C.QsciLexerIDL, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -447,7 +445,6 @@ func miqt_exec_callback_QsciLexerIDL_autoCompletionFillups(self *C.QsciLexerIDL,
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -483,12 +480,10 @@ func miqt_exec_callback_QsciLexerIDL_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -522,7 +517,6 @@ func miqt_exec_callback_QsciLexerIDL_blockEnd(self *C.QsciLexerIDL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -578,7 +572,6 @@ func miqt_exec_callback_QsciLexerIDL_blockStart(self *C.QsciLexerIDL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -609,7 +602,6 @@ func miqt_exec_callback_QsciLexerIDL_blockStartKeyword(self *C.QsciLexerIDL, cb 
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -803,7 +795,6 @@ func miqt_exec_callback_QsciLexerIDL_keywords(self *C.QsciLexerIDL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -854,7 +845,6 @@ func miqt_exec_callback_QsciLexerIDL_description(self *C.QsciLexerIDL, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1104,7 +1094,6 @@ func miqt_exec_callback_QsciLexerIDL_wordCharacters(self *C.QsciLexerIDL, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerIDL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerjava.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerjava.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerJava_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerjava.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerjava.go
@@ -353,7 +353,6 @@ func miqt_exec_callback_QsciLexerJava_language(self *C.QsciLexerJava, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -381,7 +380,6 @@ func miqt_exec_callback_QsciLexerJava_lexer(self *C.QsciLexerJava, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -434,7 +432,6 @@ func miqt_exec_callback_QsciLexerJava_autoCompletionFillups(self *C.QsciLexerJav
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -470,12 +467,10 @@ func miqt_exec_callback_QsciLexerJava_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -509,7 +504,6 @@ func miqt_exec_callback_QsciLexerJava_blockEnd(self *C.QsciLexerJava, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -565,7 +559,6 @@ func miqt_exec_callback_QsciLexerJava_blockStart(self *C.QsciLexerJava, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -596,7 +589,6 @@ func miqt_exec_callback_QsciLexerJava_blockStartKeyword(self *C.QsciLexerJava, c
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -790,7 +782,6 @@ func miqt_exec_callback_QsciLexerJava_keywords(self *C.QsciLexerJava, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -841,7 +832,6 @@ func miqt_exec_callback_QsciLexerJava_description(self *C.QsciLexerJava, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1091,7 +1081,6 @@ func miqt_exec_callback_QsciLexerJava_wordCharacters(self *C.QsciLexerJava, cb C
 
 	virtualReturn := gofunc((&QsciLexerJava{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerjavascript.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerjavascript.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerJavaScript_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerjavascript.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerjavascript.go
@@ -382,7 +382,6 @@ func miqt_exec_callback_QsciLexerJavaScript_language(self *C.QsciLexerJavaScript
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -410,7 +409,6 @@ func miqt_exec_callback_QsciLexerJavaScript_lexer(self *C.QsciLexerJavaScript, c
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -463,7 +461,6 @@ func miqt_exec_callback_QsciLexerJavaScript_autoCompletionFillups(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -499,12 +496,10 @@ func miqt_exec_callback_QsciLexerJavaScript_autoCompletionWordSeparators(self *C
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -538,7 +533,6 @@ func miqt_exec_callback_QsciLexerJavaScript_blockEnd(self *C.QsciLexerJavaScript
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -594,7 +588,6 @@ func miqt_exec_callback_QsciLexerJavaScript_blockStart(self *C.QsciLexerJavaScri
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -625,7 +618,6 @@ func miqt_exec_callback_QsciLexerJavaScript_blockStartKeyword(self *C.QsciLexerJ
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -819,7 +811,6 @@ func miqt_exec_callback_QsciLexerJavaScript_keywords(self *C.QsciLexerJavaScript
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -870,7 +861,6 @@ func miqt_exec_callback_QsciLexerJavaScript_description(self *C.QsciLexerJavaScr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1120,7 +1110,6 @@ func miqt_exec_callback_QsciLexerJavaScript_wordCharacters(self *C.QsciLexerJava
 
 	virtualReturn := gofunc((&QsciLexerJavaScript{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerjson.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerjson.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerJSON_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerjson.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerjson.go
@@ -304,7 +304,6 @@ func miqt_exec_callback_QsciLexerJSON_language(self *C.QsciLexerJSON, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -332,7 +331,6 @@ func miqt_exec_callback_QsciLexerJSON_lexer(self *C.QsciLexerJSON, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -385,7 +383,6 @@ func miqt_exec_callback_QsciLexerJSON_autoCompletionFillups(self *C.QsciLexerJSO
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -421,12 +418,10 @@ func miqt_exec_callback_QsciLexerJSON_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -460,7 +455,6 @@ func miqt_exec_callback_QsciLexerJSON_blockEnd(self *C.QsciLexerJSON, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -516,7 +510,6 @@ func miqt_exec_callback_QsciLexerJSON_blockStart(self *C.QsciLexerJSON, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -547,7 +540,6 @@ func miqt_exec_callback_QsciLexerJSON_blockStartKeyword(self *C.QsciLexerJSON, c
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -741,7 +733,6 @@ func miqt_exec_callback_QsciLexerJSON_keywords(self *C.QsciLexerJSON, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -792,7 +783,6 @@ func miqt_exec_callback_QsciLexerJSON_description(self *C.QsciLexerJSON, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1042,7 +1032,6 @@ func miqt_exec_callback_QsciLexerJSON_wordCharacters(self *C.QsciLexerJSON, cb C
 
 	virtualReturn := gofunc((&QsciLexerJSON{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerlua.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerlua.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerLua_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerlua.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerlua.go
@@ -347,7 +347,6 @@ func miqt_exec_callback_QsciLexerLua_language(self *C.QsciLexerLua, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -375,7 +374,6 @@ func miqt_exec_callback_QsciLexerLua_lexer(self *C.QsciLexerLua, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -428,7 +426,6 @@ func miqt_exec_callback_QsciLexerLua_autoCompletionFillups(self *C.QsciLexerLua,
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -464,12 +461,10 @@ func miqt_exec_callback_QsciLexerLua_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -503,7 +498,6 @@ func miqt_exec_callback_QsciLexerLua_blockEnd(self *C.QsciLexerLua, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -559,7 +553,6 @@ func miqt_exec_callback_QsciLexerLua_blockStart(self *C.QsciLexerLua, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -590,7 +583,6 @@ func miqt_exec_callback_QsciLexerLua_blockStartKeyword(self *C.QsciLexerLua, cb 
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -784,7 +776,6 @@ func miqt_exec_callback_QsciLexerLua_keywords(self *C.QsciLexerLua, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -835,7 +826,6 @@ func miqt_exec_callback_QsciLexerLua_description(self *C.QsciLexerLua, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1085,7 +1075,6 @@ func miqt_exec_callback_QsciLexerLua_wordCharacters(self *C.QsciLexerLua, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerLua{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexermakefile.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexermakefile.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerMakefile_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexermakefile.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexermakefile.go
@@ -233,7 +233,6 @@ func miqt_exec_callback_QsciLexerMakefile_language(self *C.QsciLexerMakefile, cb
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -261,7 +260,6 @@ func miqt_exec_callback_QsciLexerMakefile_lexer(self *C.QsciLexerMakefile, cb C.
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -314,7 +312,6 @@ func miqt_exec_callback_QsciLexerMakefile_autoCompletionFillups(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -350,12 +347,10 @@ func miqt_exec_callback_QsciLexerMakefile_autoCompletionWordSeparators(self *C.Q
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -389,7 +384,6 @@ func miqt_exec_callback_QsciLexerMakefile_blockEnd(self *C.QsciLexerMakefile, cb
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -445,7 +439,6 @@ func miqt_exec_callback_QsciLexerMakefile_blockStart(self *C.QsciLexerMakefile, 
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -476,7 +469,6 @@ func miqt_exec_callback_QsciLexerMakefile_blockStartKeyword(self *C.QsciLexerMak
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -670,7 +662,6 @@ func miqt_exec_callback_QsciLexerMakefile_keywords(self *C.QsciLexerMakefile, cb
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -721,7 +712,6 @@ func miqt_exec_callback_QsciLexerMakefile_description(self *C.QsciLexerMakefile,
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -971,7 +961,6 @@ func miqt_exec_callback_QsciLexerMakefile_wordCharacters(self *C.QsciLexerMakefi
 
 	virtualReturn := gofunc((&QsciLexerMakefile{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexermarkdown.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexermarkdown.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerMarkdown_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexermarkdown.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexermarkdown.go
@@ -239,7 +239,6 @@ func miqt_exec_callback_QsciLexerMarkdown_language(self *C.QsciLexerMarkdown, cb
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -267,7 +266,6 @@ func miqt_exec_callback_QsciLexerMarkdown_lexer(self *C.QsciLexerMarkdown, cb C.
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -320,7 +318,6 @@ func miqt_exec_callback_QsciLexerMarkdown_autoCompletionFillups(self *C.QsciLexe
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -356,12 +353,10 @@ func miqt_exec_callback_QsciLexerMarkdown_autoCompletionWordSeparators(self *C.Q
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -395,7 +390,6 @@ func miqt_exec_callback_QsciLexerMarkdown_blockEnd(self *C.QsciLexerMarkdown, cb
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -451,7 +445,6 @@ func miqt_exec_callback_QsciLexerMarkdown_blockStart(self *C.QsciLexerMarkdown, 
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -482,7 +475,6 @@ func miqt_exec_callback_QsciLexerMarkdown_blockStartKeyword(self *C.QsciLexerMar
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -676,7 +668,6 @@ func miqt_exec_callback_QsciLexerMarkdown_keywords(self *C.QsciLexerMarkdown, cb
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -727,7 +718,6 @@ func miqt_exec_callback_QsciLexerMarkdown_description(self *C.QsciLexerMarkdown,
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -977,7 +967,6 @@ func miqt_exec_callback_QsciLexerMarkdown_wordCharacters(self *C.QsciLexerMarkdo
 
 	virtualReturn := gofunc((&QsciLexerMarkdown{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexermatlab.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexermatlab.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerMatlab_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexermatlab.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexermatlab.go
@@ -225,7 +225,6 @@ func miqt_exec_callback_QsciLexerMatlab_language(self *C.QsciLexerMatlab, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -253,7 +252,6 @@ func miqt_exec_callback_QsciLexerMatlab_lexer(self *C.QsciLexerMatlab, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -306,7 +304,6 @@ func miqt_exec_callback_QsciLexerMatlab_autoCompletionFillups(self *C.QsciLexerM
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -342,12 +339,10 @@ func miqt_exec_callback_QsciLexerMatlab_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -381,7 +376,6 @@ func miqt_exec_callback_QsciLexerMatlab_blockEnd(self *C.QsciLexerMatlab, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -437,7 +431,6 @@ func miqt_exec_callback_QsciLexerMatlab_blockStart(self *C.QsciLexerMatlab, cb C
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -468,7 +461,6 @@ func miqt_exec_callback_QsciLexerMatlab_blockStartKeyword(self *C.QsciLexerMatla
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -662,7 +654,6 @@ func miqt_exec_callback_QsciLexerMatlab_keywords(self *C.QsciLexerMatlab, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -713,7 +704,6 @@ func miqt_exec_callback_QsciLexerMatlab_description(self *C.QsciLexerMatlab, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -963,7 +953,6 @@ func miqt_exec_callback_QsciLexerMatlab_wordCharacters(self *C.QsciLexerMatlab, 
 
 	virtualReturn := gofunc((&QsciLexerMatlab{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeroctave.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeroctave.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerOctave_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeroctave.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeroctave.go
@@ -192,7 +192,6 @@ func miqt_exec_callback_QsciLexerOctave_language(self *C.QsciLexerOctave, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -220,7 +219,6 @@ func miqt_exec_callback_QsciLexerOctave_lexer(self *C.QsciLexerOctave, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -273,7 +271,6 @@ func miqt_exec_callback_QsciLexerOctave_autoCompletionFillups(self *C.QsciLexerO
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -309,12 +306,10 @@ func miqt_exec_callback_QsciLexerOctave_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -348,7 +343,6 @@ func miqt_exec_callback_QsciLexerOctave_blockEnd(self *C.QsciLexerOctave, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -404,7 +398,6 @@ func miqt_exec_callback_QsciLexerOctave_blockStart(self *C.QsciLexerOctave, cb C
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -435,7 +428,6 @@ func miqt_exec_callback_QsciLexerOctave_blockStartKeyword(self *C.QsciLexerOctav
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -629,7 +621,6 @@ func miqt_exec_callback_QsciLexerOctave_keywords(self *C.QsciLexerOctave, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -680,7 +671,6 @@ func miqt_exec_callback_QsciLexerOctave_description(self *C.QsciLexerOctave, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -930,7 +920,6 @@ func miqt_exec_callback_QsciLexerOctave_wordCharacters(self *C.QsciLexerOctave, 
 
 	virtualReturn := gofunc((&QsciLexerOctave{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpascal.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpascal.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPascal_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpascal.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpascal.go
@@ -438,7 +438,6 @@ func miqt_exec_callback_QsciLexerPascal_language(self *C.QsciLexerPascal, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -466,7 +465,6 @@ func miqt_exec_callback_QsciLexerPascal_lexer(self *C.QsciLexerPascal, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -519,7 +517,6 @@ func miqt_exec_callback_QsciLexerPascal_autoCompletionFillups(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -555,12 +552,10 @@ func miqt_exec_callback_QsciLexerPascal_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -594,7 +589,6 @@ func miqt_exec_callback_QsciLexerPascal_blockEnd(self *C.QsciLexerPascal, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -650,7 +644,6 @@ func miqt_exec_callback_QsciLexerPascal_blockStart(self *C.QsciLexerPascal, cb C
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -681,7 +674,6 @@ func miqt_exec_callback_QsciLexerPascal_blockStartKeyword(self *C.QsciLexerPasca
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -875,7 +867,6 @@ func miqt_exec_callback_QsciLexerPascal_keywords(self *C.QsciLexerPascal, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -926,7 +917,6 @@ func miqt_exec_callback_QsciLexerPascal_description(self *C.QsciLexerPascal, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1176,7 +1166,6 @@ func miqt_exec_callback_QsciLexerPascal_wordCharacters(self *C.QsciLexerPascal, 
 
 	virtualReturn := gofunc((&QsciLexerPascal{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerperl.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerperl.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPerl_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerperl.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerperl.go
@@ -441,7 +441,6 @@ func miqt_exec_callback_QsciLexerPerl_language(self *C.QsciLexerPerl, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -469,7 +468,6 @@ func miqt_exec_callback_QsciLexerPerl_lexer(self *C.QsciLexerPerl, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -522,7 +520,6 @@ func miqt_exec_callback_QsciLexerPerl_autoCompletionFillups(self *C.QsciLexerPer
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -558,12 +555,10 @@ func miqt_exec_callback_QsciLexerPerl_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -597,7 +592,6 @@ func miqt_exec_callback_QsciLexerPerl_blockEnd(self *C.QsciLexerPerl, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -653,7 +647,6 @@ func miqt_exec_callback_QsciLexerPerl_blockStart(self *C.QsciLexerPerl, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -684,7 +677,6 @@ func miqt_exec_callback_QsciLexerPerl_blockStartKeyword(self *C.QsciLexerPerl, c
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -878,7 +870,6 @@ func miqt_exec_callback_QsciLexerPerl_keywords(self *C.QsciLexerPerl, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -929,7 +920,6 @@ func miqt_exec_callback_QsciLexerPerl_description(self *C.QsciLexerPerl, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1179,7 +1169,6 @@ func miqt_exec_callback_QsciLexerPerl_wordCharacters(self *C.QsciLexerPerl, cb C
 
 	virtualReturn := gofunc((&QsciLexerPerl{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpo.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpo.cpp
@@ -182,6 +182,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -386,6 +391,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPO_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpo.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpo.go
@@ -334,7 +334,6 @@ func miqt_exec_callback_QsciLexerPO_language(self *C.QsciLexerPO, cb C.intptr_t)
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -362,7 +361,6 @@ func miqt_exec_callback_QsciLexerPO_lexer(self *C.QsciLexerPO, cb C.intptr_t) *C
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -415,7 +413,6 @@ func miqt_exec_callback_QsciLexerPO_autoCompletionFillups(self *C.QsciLexerPO, c
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -451,12 +448,10 @@ func miqt_exec_callback_QsciLexerPO_autoCompletionWordSeparators(self *C.QsciLex
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -490,7 +485,6 @@ func miqt_exec_callback_QsciLexerPO_blockEnd(self *C.QsciLexerPO, cb C.intptr_t,
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -546,7 +540,6 @@ func miqt_exec_callback_QsciLexerPO_blockStart(self *C.QsciLexerPO, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -577,7 +570,6 @@ func miqt_exec_callback_QsciLexerPO_blockStartKeyword(self *C.QsciLexerPO, cb C.
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -771,7 +763,6 @@ func miqt_exec_callback_QsciLexerPO_keywords(self *C.QsciLexerPO, cb C.intptr_t,
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -822,7 +813,6 @@ func miqt_exec_callback_QsciLexerPO_description(self *C.QsciLexerPO, cb C.intptr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1072,7 +1062,6 @@ func miqt_exec_callback_QsciLexerPO_wordCharacters(self *C.QsciLexerPO, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerPO{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpostscript.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpostscript.cpp
@@ -218,6 +218,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -422,6 +427,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPostScript_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpostscript.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpostscript.go
@@ -418,7 +418,6 @@ func miqt_exec_callback_QsciLexerPostScript_language(self *C.QsciLexerPostScript
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -446,7 +445,6 @@ func miqt_exec_callback_QsciLexerPostScript_lexer(self *C.QsciLexerPostScript, c
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -499,7 +497,6 @@ func miqt_exec_callback_QsciLexerPostScript_autoCompletionFillups(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -535,12 +532,10 @@ func miqt_exec_callback_QsciLexerPostScript_autoCompletionWordSeparators(self *C
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -574,7 +569,6 @@ func miqt_exec_callback_QsciLexerPostScript_blockEnd(self *C.QsciLexerPostScript
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -630,7 +624,6 @@ func miqt_exec_callback_QsciLexerPostScript_blockStart(self *C.QsciLexerPostScri
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -661,7 +654,6 @@ func miqt_exec_callback_QsciLexerPostScript_blockStartKeyword(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -855,7 +847,6 @@ func miqt_exec_callback_QsciLexerPostScript_keywords(self *C.QsciLexerPostScript
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -906,7 +897,6 @@ func miqt_exec_callback_QsciLexerPostScript_description(self *C.QsciLexerPostScr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1156,7 +1146,6 @@ func miqt_exec_callback_QsciLexerPostScript_wordCharacters(self *C.QsciLexerPost
 
 	virtualReturn := gofunc((&QsciLexerPostScript{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpov.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpov.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPOV_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpov.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpov.go
@@ -394,7 +394,6 @@ func miqt_exec_callback_QsciLexerPOV_language(self *C.QsciLexerPOV, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -422,7 +421,6 @@ func miqt_exec_callback_QsciLexerPOV_lexer(self *C.QsciLexerPOV, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -475,7 +473,6 @@ func miqt_exec_callback_QsciLexerPOV_autoCompletionFillups(self *C.QsciLexerPOV,
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -511,12 +508,10 @@ func miqt_exec_callback_QsciLexerPOV_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -550,7 +545,6 @@ func miqt_exec_callback_QsciLexerPOV_blockEnd(self *C.QsciLexerPOV, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -606,7 +600,6 @@ func miqt_exec_callback_QsciLexerPOV_blockStart(self *C.QsciLexerPOV, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -637,7 +630,6 @@ func miqt_exec_callback_QsciLexerPOV_blockStartKeyword(self *C.QsciLexerPOV, cb 
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -831,7 +823,6 @@ func miqt_exec_callback_QsciLexerPOV_keywords(self *C.QsciLexerPOV, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -882,7 +873,6 @@ func miqt_exec_callback_QsciLexerPOV_description(self *C.QsciLexerPOV, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1132,7 +1122,6 @@ func miqt_exec_callback_QsciLexerPOV_wordCharacters(self *C.QsciLexerPOV, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPOV{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerproperties.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerproperties.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerProperties_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerproperties.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerproperties.go
@@ -314,7 +314,6 @@ func miqt_exec_callback_QsciLexerProperties_language(self *C.QsciLexerProperties
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -342,7 +341,6 @@ func miqt_exec_callback_QsciLexerProperties_lexer(self *C.QsciLexerProperties, c
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -395,7 +393,6 @@ func miqt_exec_callback_QsciLexerProperties_autoCompletionFillups(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -431,12 +428,10 @@ func miqt_exec_callback_QsciLexerProperties_autoCompletionWordSeparators(self *C
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -470,7 +465,6 @@ func miqt_exec_callback_QsciLexerProperties_blockEnd(self *C.QsciLexerProperties
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -526,7 +520,6 @@ func miqt_exec_callback_QsciLexerProperties_blockStart(self *C.QsciLexerProperti
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -557,7 +550,6 @@ func miqt_exec_callback_QsciLexerProperties_blockStartKeyword(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -751,7 +743,6 @@ func miqt_exec_callback_QsciLexerProperties_keywords(self *C.QsciLexerProperties
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -802,7 +793,6 @@ func miqt_exec_callback_QsciLexerProperties_description(self *C.QsciLexerPropert
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1052,7 +1042,6 @@ func miqt_exec_callback_QsciLexerProperties_wordCharacters(self *C.QsciLexerProp
 
 	virtualReturn := gofunc((&QsciLexerProperties{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpython.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpython.cpp
@@ -216,6 +216,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -405,6 +410,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerPython_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerpython.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerpython.go
@@ -506,7 +506,6 @@ func miqt_exec_callback_QsciLexerPython_language(self *C.QsciLexerPython, cb C.i
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -534,7 +533,6 @@ func miqt_exec_callback_QsciLexerPython_lexer(self *C.QsciLexerPython, cb C.intp
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -587,7 +585,6 @@ func miqt_exec_callback_QsciLexerPython_autoCompletionFillups(self *C.QsciLexerP
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -623,12 +620,10 @@ func miqt_exec_callback_QsciLexerPython_autoCompletionWordSeparators(self *C.Qsc
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -662,7 +657,6 @@ func miqt_exec_callback_QsciLexerPython_blockEnd(self *C.QsciLexerPython, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -718,7 +712,6 @@ func miqt_exec_callback_QsciLexerPython_blockStart(self *C.QsciLexerPython, cb C
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -749,7 +742,6 @@ func miqt_exec_callback_QsciLexerPython_blockStartKeyword(self *C.QsciLexerPytho
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -918,7 +910,6 @@ func miqt_exec_callback_QsciLexerPython_keywords(self *C.QsciLexerPython, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -969,7 +960,6 @@ func miqt_exec_callback_QsciLexerPython_description(self *C.QsciLexerPython, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1219,7 +1209,6 @@ func miqt_exec_callback_QsciLexerPython_wordCharacters(self *C.QsciLexerPython, 
 
 	virtualReturn := gofunc((&QsciLexerPython{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerruby.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerruby.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerRuby_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerruby.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerruby.go
@@ -347,7 +347,6 @@ func miqt_exec_callback_QsciLexerRuby_language(self *C.QsciLexerRuby, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -375,7 +374,6 @@ func miqt_exec_callback_QsciLexerRuby_lexer(self *C.QsciLexerRuby, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -428,7 +426,6 @@ func miqt_exec_callback_QsciLexerRuby_autoCompletionFillups(self *C.QsciLexerRub
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -464,12 +461,10 @@ func miqt_exec_callback_QsciLexerRuby_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -503,7 +498,6 @@ func miqt_exec_callback_QsciLexerRuby_blockEnd(self *C.QsciLexerRuby, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -559,7 +553,6 @@ func miqt_exec_callback_QsciLexerRuby_blockStart(self *C.QsciLexerRuby, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -590,7 +583,6 @@ func miqt_exec_callback_QsciLexerRuby_blockStartKeyword(self *C.QsciLexerRuby, c
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -784,7 +776,6 @@ func miqt_exec_callback_QsciLexerRuby_keywords(self *C.QsciLexerRuby, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -835,7 +826,6 @@ func miqt_exec_callback_QsciLexerRuby_description(self *C.QsciLexerRuby, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1085,7 +1075,6 @@ func miqt_exec_callback_QsciLexerRuby_wordCharacters(self *C.QsciLexerRuby, cb C
 
 	virtualReturn := gofunc((&QsciLexerRuby{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerspice.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerspice.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerSpice_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerspice.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerspice.go
@@ -229,7 +229,6 @@ func miqt_exec_callback_QsciLexerSpice_language(self *C.QsciLexerSpice, cb C.int
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -257,7 +256,6 @@ func miqt_exec_callback_QsciLexerSpice_lexer(self *C.QsciLexerSpice, cb C.intptr
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -310,7 +308,6 @@ func miqt_exec_callback_QsciLexerSpice_autoCompletionFillups(self *C.QsciLexerSp
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -346,12 +343,10 @@ func miqt_exec_callback_QsciLexerSpice_autoCompletionWordSeparators(self *C.Qsci
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -385,7 +380,6 @@ func miqt_exec_callback_QsciLexerSpice_blockEnd(self *C.QsciLexerSpice, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -441,7 +435,6 @@ func miqt_exec_callback_QsciLexerSpice_blockStart(self *C.QsciLexerSpice, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -472,7 +465,6 @@ func miqt_exec_callback_QsciLexerSpice_blockStartKeyword(self *C.QsciLexerSpice,
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -666,7 +658,6 @@ func miqt_exec_callback_QsciLexerSpice_keywords(self *C.QsciLexerSpice, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -717,7 +708,6 @@ func miqt_exec_callback_QsciLexerSpice_description(self *C.QsciLexerSpice, cb C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -967,7 +957,6 @@ func miqt_exec_callback_QsciLexerSpice_wordCharacters(self *C.QsciLexerSpice, cb
 
 	virtualReturn := gofunc((&QsciLexerSpice{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexersql.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexersql.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerSQL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexersql.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexersql.go
@@ -434,7 +434,6 @@ func miqt_exec_callback_QsciLexerSQL_language(self *C.QsciLexerSQL, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -462,7 +461,6 @@ func miqt_exec_callback_QsciLexerSQL_lexer(self *C.QsciLexerSQL, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -515,7 +513,6 @@ func miqt_exec_callback_QsciLexerSQL_autoCompletionFillups(self *C.QsciLexerSQL,
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -551,12 +548,10 @@ func miqt_exec_callback_QsciLexerSQL_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -590,7 +585,6 @@ func miqt_exec_callback_QsciLexerSQL_blockEnd(self *C.QsciLexerSQL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -646,7 +640,6 @@ func miqt_exec_callback_QsciLexerSQL_blockStart(self *C.QsciLexerSQL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -677,7 +670,6 @@ func miqt_exec_callback_QsciLexerSQL_blockStartKeyword(self *C.QsciLexerSQL, cb 
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -871,7 +863,6 @@ func miqt_exec_callback_QsciLexerSQL_keywords(self *C.QsciLexerSQL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -922,7 +913,6 @@ func miqt_exec_callback_QsciLexerSQL_description(self *C.QsciLexerSQL, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1172,7 +1162,6 @@ func miqt_exec_callback_QsciLexerSQL_wordCharacters(self *C.QsciLexerSQL, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerSQL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexertcl.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexertcl.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerTCL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexertcl.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexertcl.go
@@ -300,7 +300,6 @@ func miqt_exec_callback_QsciLexerTCL_language(self *C.QsciLexerTCL, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -328,7 +327,6 @@ func miqt_exec_callback_QsciLexerTCL_lexer(self *C.QsciLexerTCL, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -381,7 +379,6 @@ func miqt_exec_callback_QsciLexerTCL_autoCompletionFillups(self *C.QsciLexerTCL,
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -417,12 +414,10 @@ func miqt_exec_callback_QsciLexerTCL_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -456,7 +451,6 @@ func miqt_exec_callback_QsciLexerTCL_blockEnd(self *C.QsciLexerTCL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -512,7 +506,6 @@ func miqt_exec_callback_QsciLexerTCL_blockStart(self *C.QsciLexerTCL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -543,7 +536,6 @@ func miqt_exec_callback_QsciLexerTCL_blockStartKeyword(self *C.QsciLexerTCL, cb 
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -737,7 +729,6 @@ func miqt_exec_callback_QsciLexerTCL_keywords(self *C.QsciLexerTCL, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -788,7 +779,6 @@ func miqt_exec_callback_QsciLexerTCL_description(self *C.QsciLexerTCL, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1038,7 +1028,6 @@ func miqt_exec_callback_QsciLexerTCL_wordCharacters(self *C.QsciLexerTCL, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerTCL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexertex.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexertex.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerTeX_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexertex.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexertex.go
@@ -293,7 +293,6 @@ func miqt_exec_callback_QsciLexerTeX_language(self *C.QsciLexerTeX, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -321,7 +320,6 @@ func miqt_exec_callback_QsciLexerTeX_lexer(self *C.QsciLexerTeX, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -374,7 +372,6 @@ func miqt_exec_callback_QsciLexerTeX_autoCompletionFillups(self *C.QsciLexerTeX,
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -410,12 +407,10 @@ func miqt_exec_callback_QsciLexerTeX_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -449,7 +444,6 @@ func miqt_exec_callback_QsciLexerTeX_blockEnd(self *C.QsciLexerTeX, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -505,7 +499,6 @@ func miqt_exec_callback_QsciLexerTeX_blockStart(self *C.QsciLexerTeX, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -536,7 +529,6 @@ func miqt_exec_callback_QsciLexerTeX_blockStartKeyword(self *C.QsciLexerTeX, cb 
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -730,7 +722,6 @@ func miqt_exec_callback_QsciLexerTeX_keywords(self *C.QsciLexerTeX, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -781,7 +772,6 @@ func miqt_exec_callback_QsciLexerTeX_description(self *C.QsciLexerTeX, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1031,7 +1021,6 @@ func miqt_exec_callback_QsciLexerTeX_wordCharacters(self *C.QsciLexerTeX, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerTeX{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerverilog.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerverilog.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -350,6 +355,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerVerilog_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerverilog.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerverilog.go
@@ -353,7 +353,6 @@ func miqt_exec_callback_QsciLexerVerilog_language(self *C.QsciLexerVerilog, cb C
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -381,7 +380,6 @@ func miqt_exec_callback_QsciLexerVerilog_lexer(self *C.QsciLexerVerilog, cb C.in
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -434,7 +432,6 @@ func miqt_exec_callback_QsciLexerVerilog_autoCompletionFillups(self *C.QsciLexer
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -470,12 +467,10 @@ func miqt_exec_callback_QsciLexerVerilog_autoCompletionWordSeparators(self *C.Qs
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -509,7 +504,6 @@ func miqt_exec_callback_QsciLexerVerilog_blockEnd(self *C.QsciLexerVerilog, cb C
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -565,7 +559,6 @@ func miqt_exec_callback_QsciLexerVerilog_blockStart(self *C.QsciLexerVerilog, cb
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -596,7 +589,6 @@ func miqt_exec_callback_QsciLexerVerilog_blockStartKeyword(self *C.QsciLexerVeri
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -790,7 +782,6 @@ func miqt_exec_callback_QsciLexerVerilog_keywords(self *C.QsciLexerVerilog, cb C
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -841,7 +832,6 @@ func miqt_exec_callback_QsciLexerVerilog_description(self *C.QsciLexerVerilog, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1091,7 +1081,6 @@ func miqt_exec_callback_QsciLexerVerilog_wordCharacters(self *C.QsciLexerVerilog
 
 	virtualReturn := gofunc((&QsciLexerVerilog{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexervhdl.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexervhdl.cpp
@@ -236,6 +236,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -440,6 +445,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerVHDL_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexervhdl.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexervhdl.go
@@ -456,7 +456,6 @@ func miqt_exec_callback_QsciLexerVHDL_language(self *C.QsciLexerVHDL, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -484,7 +483,6 @@ func miqt_exec_callback_QsciLexerVHDL_lexer(self *C.QsciLexerVHDL, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -537,7 +535,6 @@ func miqt_exec_callback_QsciLexerVHDL_autoCompletionFillups(self *C.QsciLexerVHD
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -573,12 +570,10 @@ func miqt_exec_callback_QsciLexerVHDL_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -612,7 +607,6 @@ func miqt_exec_callback_QsciLexerVHDL_blockEnd(self *C.QsciLexerVHDL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -668,7 +662,6 @@ func miqt_exec_callback_QsciLexerVHDL_blockStart(self *C.QsciLexerVHDL, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -699,7 +692,6 @@ func miqt_exec_callback_QsciLexerVHDL_blockStartKeyword(self *C.QsciLexerVHDL, c
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -893,7 +885,6 @@ func miqt_exec_callback_QsciLexerVHDL_keywords(self *C.QsciLexerVHDL, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -944,7 +935,6 @@ func miqt_exec_callback_QsciLexerVHDL_description(self *C.QsciLexerVHDL, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1194,7 +1184,6 @@ func miqt_exec_callback_QsciLexerVHDL_wordCharacters(self *C.QsciLexerVHDL, cb C
 
 	virtualReturn := gofunc((&QsciLexerVHDL{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerxml.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerxml.cpp
@@ -200,6 +200,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -404,6 +409,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerXML_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexerxml.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexerxml.go
@@ -340,7 +340,6 @@ func miqt_exec_callback_QsciLexerXML_language(self *C.QsciLexerXML, cb C.intptr_
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -368,7 +367,6 @@ func miqt_exec_callback_QsciLexerXML_lexer(self *C.QsciLexerXML, cb C.intptr_t) 
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -421,7 +419,6 @@ func miqt_exec_callback_QsciLexerXML_autoCompletionFillups(self *C.QsciLexerXML,
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -457,12 +454,10 @@ func miqt_exec_callback_QsciLexerXML_autoCompletionWordSeparators(self *C.QsciLe
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -496,7 +491,6 @@ func miqt_exec_callback_QsciLexerXML_blockEnd(self *C.QsciLexerXML, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -552,7 +546,6 @@ func miqt_exec_callback_QsciLexerXML_blockStart(self *C.QsciLexerXML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -583,7 +576,6 @@ func miqt_exec_callback_QsciLexerXML_blockStartKeyword(self *C.QsciLexerXML, cb 
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -777,7 +769,6 @@ func miqt_exec_callback_QsciLexerXML_keywords(self *C.QsciLexerXML, cb C.intptr_
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -828,7 +819,6 @@ func miqt_exec_callback_QsciLexerXML_description(self *C.QsciLexerXML, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1078,7 +1068,6 @@ func miqt_exec_callback_QsciLexerXML_wordCharacters(self *C.QsciLexerXML, cb C.i
 
 	virtualReturn := gofunc((&QsciLexerXML{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeryaml.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeryaml.cpp
@@ -164,6 +164,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -368,6 +373,7 @@ public:
 		int sigval1 = style;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciLexerYAML_description(this, handle__description, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qscilexeryaml.go
+++ b/qt-restricted-extras/qscintilla6/gen_qscilexeryaml.go
@@ -310,7 +310,6 @@ func miqt_exec_callback_QsciLexerYAML_language(self *C.QsciLexerYAML, cb C.intpt
 
 	virtualReturn := gofunc()
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -338,7 +337,6 @@ func miqt_exec_callback_QsciLexerYAML_lexer(self *C.QsciLexerYAML, cb C.intptr_t
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_Lexer)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -391,7 +389,6 @@ func miqt_exec_callback_QsciLexerYAML_autoCompletionFillups(self *C.QsciLexerYAM
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_AutoCompletionFillups)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -427,12 +424,10 @@ func miqt_exec_callback_QsciLexerYAML_autoCompletionWordSeparators(self *C.QsciL
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_AutoCompletionWordSeparators)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -466,7 +461,6 @@ func miqt_exec_callback_QsciLexerYAML_blockEnd(self *C.QsciLexerYAML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_BlockEnd, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -522,7 +516,6 @@ func miqt_exec_callback_QsciLexerYAML_blockStart(self *C.QsciLexerYAML, cb C.int
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_BlockStart, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -553,7 +546,6 @@ func miqt_exec_callback_QsciLexerYAML_blockStartKeyword(self *C.QsciLexerYAML, c
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_BlockStartKeyword, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -747,7 +739,6 @@ func miqt_exec_callback_QsciLexerYAML_keywords(self *C.QsciLexerYAML, cb C.intpt
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_Keywords, slotval1)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 
@@ -798,7 +789,6 @@ func miqt_exec_callback_QsciLexerYAML_description(self *C.QsciLexerYAML, cb C.in
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1048,7 +1038,6 @@ func miqt_exec_callback_QsciLexerYAML_wordCharacters(self *C.QsciLexerYAML, cb C
 
 	virtualReturn := gofunc((&QsciLexerYAML{h: self}).callVirtualBase_WordCharacters)
 	virtualReturn_Cstring := C.CString(virtualReturn)
-	defer C.free(unsafe.Pointer(virtualReturn_Cstring))
 
 	return virtualReturn_Cstring
 

--- a/qt-restricted-extras/qscintilla6/gen_qsciscintilla.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qsciscintilla.cpp
@@ -235,6 +235,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1831,6 +1836,7 @@ public:
 		bool* sigval2 = &rectangular;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciScintilla_fromMimeData(this, handle__fromMimeData, sigval1, sigval2);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt-restricted-extras/qscintilla6/gen_qsciscintilla.go
+++ b/qt-restricted-extras/qscintilla6/gen_qsciscintilla.go
@@ -2064,12 +2064,10 @@ func miqt_exec_callback_QsciScintilla_apiContext(self *C.QsciScintilla, cb C.int
 
 	virtualReturn := gofunc((&QsciScintilla{h: self}).callVirtualBase_ApiContext, slotval1, slotval2, slotval3)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt-restricted-extras/qscintilla6/gen_qsciscintillabase.cpp
+++ b/qt-restricted-extras/qscintilla6/gen_qsciscintillabase.cpp
@@ -184,6 +184,7 @@ public:
 		bool* sigval2 = &rectangular;
 		struct miqt_string callback_return_value = miqt_exec_callback_QsciScintillaBase_fromMimeData(this, handle__fromMimeData, sigval1, sigval2);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt/designer/gen_abstractintegration.cpp
+++ b/qt/designer/gen_abstractintegration.cpp
@@ -132,6 +132,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegrationInterface_headerSuffix(this, handle__headerSuffix);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -235,6 +236,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegrationInterface_contextHelpId(this, handle__contextHelpId);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -1294,6 +1296,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegration_headerSuffix(this, handle__headerSuffix);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -1464,6 +1467,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegration_contextHelpId(this, handle__contextHelpId);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/designer/gen_abstractintegration.go
+++ b/qt/designer/gen_abstractintegration.go
@@ -629,7 +629,6 @@ func miqt_exec_callback_QDesignerIntegrationInterface_headerSuffix(self *C.QDesi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -772,7 +771,6 @@ func miqt_exec_callback_QDesignerIntegrationInterface_contextHelpId(self *C.QDes
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1511,7 +1509,6 @@ func miqt_exec_callback_QDesignerIntegration_headerSuffix(self *C.QDesignerInteg
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1784,7 +1781,6 @@ func miqt_exec_callback_QDesignerIntegration_contextHelpId(self *C.QDesignerInte
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/designer/gen_abstractmetadatabase.cpp
+++ b/qt/designer/gen_abstractmetadatabase.cpp
@@ -157,6 +157,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(callback_return_value_arr[i]);
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/designer/gen_abstractmetadatabase.go
+++ b/qt/designer/gen_abstractmetadatabase.go
@@ -406,7 +406,6 @@ func miqt_exec_callback_QDesignerMetaDataBaseInterface_objects(self *C.QDesigner
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QObject)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QObject)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt/designer/gen_abstractpropertyeditor.cpp
+++ b/qt/designer/gen_abstractpropertyeditor.cpp
@@ -161,6 +161,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerPropertyEditorInterface_currentPropertyName(this, handle__currentPropertyName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/designer/gen_abstractpropertyeditor.go
+++ b/qt/designer/gen_abstractpropertyeditor.go
@@ -400,7 +400,6 @@ func miqt_exec_callback_QDesignerPropertyEditorInterface_currentPropertyName(sel
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/designer/gen_abstractresourcebrowser.cpp
+++ b/qt/designer/gen_abstractresourcebrowser.cpp
@@ -136,6 +136,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerResourceBrowserInterface_currentPath(this, handle__currentPath);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/designer/gen_abstractresourcebrowser.go
+++ b/qt/designer/gen_abstractresourcebrowser.go
@@ -366,7 +366,6 @@ func miqt_exec_callback_QDesignerResourceBrowserInterface_currentPath(self *C.QD
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/designer/gen_abstractwidgetbox.cpp
+++ b/qt/designer/gen_abstractwidgetbox.cpp
@@ -294,6 +294,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetBoxInterface_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/designer/gen_abstractwidgetbox.go
+++ b/qt/designer/gen_abstractwidgetbox.go
@@ -593,7 +593,6 @@ func miqt_exec_callback_QDesignerWidgetBoxInterface_fileName(self *C.QDesignerWi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qabstractitemdelegate.cpp
+++ b/qt/gen_qabstractitemdelegate.cpp
@@ -265,6 +265,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qabstractitemdelegate.go
+++ b/qt/gen_qabstractitemdelegate.go
@@ -634,7 +634,6 @@ func miqt_exec_callback_QAbstractItemDelegate_paintingRoles(self *C.QAbstractIte
 
 	virtualReturn := gofunc((&QAbstractItemDelegate{h: self}).callVirtualBase_PaintingRoles)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt/gen_qabstractitemmodel.cpp
+++ b/qt/gen_qabstractitemmodel.cpp
@@ -629,6 +629,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -981,6 +986,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -3141,6 +3147,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -3452,6 +3463,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -4954,6 +4966,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -5265,6 +5282,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qabstractitemmodel.go
+++ b/qt/gen_qabstractitemmodel.go
@@ -1674,9 +1674,7 @@ func miqt_exec_callback_QAbstractItemModel_itemData(self *C.QAbstractItemModel, 
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1781,12 +1779,10 @@ func miqt_exec_callback_QAbstractItemModel_mimeTypes(self *C.QAbstractItemModel,
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2339,7 +2335,6 @@ func miqt_exec_callback_QAbstractItemModel_match(self *C.QAbstractItemModel, cb 
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -2413,9 +2408,7 @@ func miqt_exec_callback_QAbstractItemModel_roleNames(self *C.QAbstractItemModel,
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -3809,9 +3802,7 @@ func miqt_exec_callback_QAbstractTableModel_itemData(self *C.QAbstractTableModel
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -3916,12 +3907,10 @@ func miqt_exec_callback_QAbstractTableModel_mimeTypes(self *C.QAbstractTableMode
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -4410,7 +4399,6 @@ func miqt_exec_callback_QAbstractTableModel_match(self *C.QAbstractTableModel, c
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -4484,9 +4472,7 @@ func miqt_exec_callback_QAbstractTableModel_roleNames(self *C.QAbstractTableMode
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -5563,9 +5549,7 @@ func miqt_exec_callback_QAbstractListModel_itemData(self *C.QAbstractListModel, 
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -5670,12 +5654,10 @@ func miqt_exec_callback_QAbstractListModel_mimeTypes(self *C.QAbstractListModel,
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -6164,7 +6146,6 @@ func miqt_exec_callback_QAbstractListModel_match(self *C.QAbstractListModel, cb 
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -6238,9 +6219,7 @@ func miqt_exec_callback_QAbstractListModel_roleNames(self *C.QAbstractListModel,
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qabstractitemview.cpp
+++ b/qt/gen_qabstractitemview.cpp
@@ -783,6 +783,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qabstractitemview.go
+++ b/qt/gen_qabstractitemview.go
@@ -1927,7 +1927,6 @@ func miqt_exec_callback_QAbstractItemView_selectedIndexes(self *C.QAbstractItemV
 
 	virtualReturn := gofunc((&QAbstractItemView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qabstractproxymodel.cpp
+++ b/qt/gen_qabstractproxymodel.cpp
@@ -576,6 +576,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -831,6 +836,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qabstractproxymodel.go
+++ b/qt/gen_qabstractproxymodel.go
@@ -936,9 +936,7 @@ func miqt_exec_callback_QAbstractProxyModel_itemData(self *C.QAbstractProxyModel
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1455,12 +1453,10 @@ func miqt_exec_callback_QAbstractProxyModel_mimeTypes(self *C.QAbstractProxyMode
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1851,7 +1847,6 @@ func miqt_exec_callback_QAbstractProxyModel_match(self *C.QAbstractProxyModel, c
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1895,9 +1890,7 @@ func miqt_exec_callback_QAbstractProxyModel_roleNames(self *C.QAbstractProxyMode
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qcolumnview.cpp
+++ b/qt/gen_qcolumnview.cpp
@@ -866,6 +866,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qcolumnview.go
+++ b/qt/gen_qcolumnview.go
@@ -1677,7 +1677,6 @@ func miqt_exec_callback_QColumnView_selectedIndexes(self *C.QColumnView, cb C.in
 
 	virtualReturn := gofunc((&QColumnView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qcompleter.cpp
+++ b/qt/gen_qcompleter.cpp
@@ -64,6 +64,7 @@ public:
 		QModelIndex* sigval1 = const_cast<QModelIndex*>(&index_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QCompleter_pathFromIndex(this, handle__pathFromIndex, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -94,6 +95,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qcompleter.go
+++ b/qt/gen_qcompleter.go
@@ -538,7 +538,6 @@ func miqt_exec_callback_QCompleter_pathFromIndex(self *C.QCompleter, cb C.intptr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -584,12 +583,10 @@ func miqt_exec_callback_QCompleter_splitPath(self *C.QCompleter, cb C.intptr_t, 
 
 	virtualReturn := gofunc((&QCompleter{h: self}).callVirtualBase_SplitPath, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt/gen_qconcatenatetablesproxymodel.cpp
+++ b/qt/gen_qconcatenatetablesproxymodel.cpp
@@ -304,6 +304,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -716,6 +721,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qconcatenatetablesproxymodel.go
+++ b/qt/gen_qconcatenatetablesproxymodel.go
@@ -726,9 +726,7 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_itemData(self *C.QConcatena
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1015,12 +1013,10 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_mimeTypes(self *C.QConcaten
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1671,7 +1667,6 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_match(self *C.QConcatenateT
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1715,9 +1710,7 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_roleNames(self *C.QConcaten
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qdatetimeedit.cpp
+++ b/qt/gen_qdatetimeedit.cpp
@@ -452,6 +452,7 @@ public:
 		QDateTime* sigval1 = const_cast<QDateTime*>(&dt_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QDateTimeEdit_textFromDateTime(this, handle__textFromDateTime, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -2681,6 +2682,7 @@ public:
 		QDateTime* sigval1 = const_cast<QDateTime*>(&dt_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QTimeEdit_textFromDateTime(this, handle__textFromDateTime, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -4649,6 +4651,7 @@ public:
 		QDateTime* sigval1 = const_cast<QDateTime*>(&dt_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QDateEdit_textFromDateTime(this, handle__textFromDateTime, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qdatetimeedit.go
+++ b/qt/gen_qdatetimeedit.go
@@ -982,7 +982,6 @@ func miqt_exec_callback_QDateTimeEdit_textFromDateTime(self *C.QDateTimeEdit, cb
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -2775,7 +2774,6 @@ func miqt_exec_callback_QTimeEdit_textFromDateTime(self *C.QTimeEdit, cb C.intpt
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -4568,7 +4566,6 @@ func miqt_exec_callback_QDateEdit_textFromDateTime(self *C.QDateEdit, cb C.intpt
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qdirmodel.cpp
+++ b/qt/gen_qdirmodel.cpp
@@ -289,6 +289,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -703,6 +708,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qdirmodel.go
+++ b/qt/gen_qdirmodel.go
@@ -1084,12 +1084,10 @@ func miqt_exec_callback_QDirModel_mimeTypes(self *C.QDirModel, cb C.intptr_t) C.
 
 	virtualReturn := gofunc((&QDirModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1306,9 +1304,7 @@ func miqt_exec_callback_QDirModel_itemData(self *C.QDirModel, cb C.intptr_t, ind
 
 	virtualReturn := gofunc((&QDirModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1768,7 +1764,6 @@ func miqt_exec_callback_QDirModel_match(self *C.QDirModel, cb C.intptr_t, start 
 
 	virtualReturn := gofunc((&QDirModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1842,9 +1837,7 @@ func miqt_exec_callback_QDirModel_roleNames(self *C.QDirModel, cb C.intptr_t) C.
 
 	virtualReturn := gofunc((&QDirModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qfile.cpp
+++ b/qt/gen_qfile.cpp
@@ -70,6 +70,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QFile_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qfile.go
+++ b/qt/gen_qfile.go
@@ -498,7 +498,6 @@ func miqt_exec_callback_QFile_fileName(self *C.QFile, cb C.intptr_t) C.struct_mi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qfileiconprovider.cpp
+++ b/qt/gen_qfileiconprovider.cpp
@@ -74,6 +74,7 @@ public:
 		QFileInfo* sigval1 = const_cast<QFileInfo*>(&info_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QFileIconProvider_type(this, handle__type, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qfileiconprovider.go
+++ b/qt/gen_qfileiconprovider.go
@@ -185,7 +185,6 @@ func miqt_exec_callback_QFileIconProvider_type(self *C.QFileIconProvider, cb C.i
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qfilesystemmodel.cpp
+++ b/qt/gen_qfilesystemmodel.cpp
@@ -349,6 +349,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -739,6 +744,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qfilesystemmodel.go
+++ b/qt/gen_qfilesystemmodel.go
@@ -1320,12 +1320,10 @@ func miqt_exec_callback_QFileSystemModel_mimeTypes(self *C.QFileSystemModel, cb 
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1562,9 +1560,7 @@ func miqt_exec_callback_QFileSystemModel_itemData(self *C.QFileSystemModel, cb C
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1970,7 +1966,6 @@ func miqt_exec_callback_QFileSystemModel_match(self *C.QFileSystemModel, cb C.in
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -2044,9 +2039,7 @@ func miqt_exec_callback_QFileSystemModel_roleNames(self *C.QFileSystemModel, cb 
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qheaderview.cpp
+++ b/qt/gen_qheaderview.cpp
@@ -1012,6 +1012,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qheaderview.go
+++ b/qt/gen_qheaderview.go
@@ -2376,7 +2376,6 @@ func miqt_exec_callback_QHeaderView_selectedIndexes(self *C.QHeaderView, cb C.in
 
 	virtualReturn := gofunc((&QHeaderView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qiconengine.cpp
+++ b/qt/gen_qiconengine.cpp
@@ -171,6 +171,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QIconEngine_key(this, handle__key);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -245,6 +246,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -261,6 +263,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QIconEngine_iconName(this, handle__iconName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qiconengine.go
+++ b/qt/gen_qiconengine.go
@@ -334,7 +334,6 @@ func miqt_exec_callback_QIconEngine_key(self *C.QIconEngine, cb C.intptr_t) C.st
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -449,7 +448,6 @@ func miqt_exec_callback_QIconEngine_availableSizes(self *C.QIconEngine, cb C.int
 
 	virtualReturn := gofunc((&QIconEngine{h: self}).callVirtualBase_AvailableSizes, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]*C.QSize)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -484,7 +482,6 @@ func miqt_exec_callback_QIconEngine_iconName(self *C.QIconEngine, cb C.intptr_t)
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qidentityproxymodel.cpp
+++ b/qt/gen_qidentityproxymodel.cpp
@@ -319,6 +319,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -813,6 +814,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qidentityproxymodel.go
+++ b/qt/gen_qidentityproxymodel.go
@@ -966,7 +966,6 @@ func miqt_exec_callback_QIdentityProxyModel_match(self *C.QIdentityProxyModel, c
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1319,9 +1318,7 @@ func miqt_exec_callback_QIdentityProxyModel_itemData(self *C.QIdentityProxyModel
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1768,12 +1765,10 @@ func miqt_exec_callback_QIdentityProxyModel_mimeTypes(self *C.QIdentityProxyMode
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1866,9 +1861,7 @@ func miqt_exec_callback_QIdentityProxyModel_roleNames(self *C.QIdentityProxyMode
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qimageiohandler.cpp
+++ b/qt/gen_qimageiohandler.cpp
@@ -66,6 +66,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QImageIOHandler_name(this, handle__name);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt/gen_qitemdelegate.cpp
+++ b/qt/gen_qitemdelegate.cpp
@@ -398,6 +398,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qitemdelegate.go
+++ b/qt/gen_qitemdelegate.go
@@ -824,7 +824,6 @@ func miqt_exec_callback_QItemDelegate_paintingRoles(self *C.QItemDelegate, cb C.
 
 	virtualReturn := gofunc((&QItemDelegate{h: self}).callVirtualBase_PaintingRoles)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt/gen_qitemeditorfactory.cpp
+++ b/qt/gen_qitemeditorfactory.cpp
@@ -73,6 +73,7 @@ public:
 		int sigval1 = userType;
 		struct miqt_string callback_return_value = miqt_exec_callback_QItemEditorFactory_valuePropertyName(this, handle__valuePropertyName, sigval1);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt/gen_qlistview.cpp
+++ b/qt/gen_qlistview.cpp
@@ -663,6 +663,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qlistview.go
+++ b/qt/gen_qlistview.go
@@ -1554,7 +1554,6 @@ func miqt_exec_callback_QListView_selectedIndexes(self *C.QListView, cb C.intptr
 
 	virtualReturn := gofunc((&QListView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qlistwidget.cpp
+++ b/qt/gen_qlistwidget.cpp
@@ -740,6 +740,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1277,6 +1282,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qlistwidget.go
+++ b/qt/gen_qlistwidget.go
@@ -1682,12 +1682,10 @@ func miqt_exec_callback_QListWidget_mimeTypes(self *C.QListWidget, cb C.intptr_t
 
 	virtualReturn := gofunc((&QListWidget{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2513,7 +2511,6 @@ func miqt_exec_callback_QListWidget_selectedIndexes(self *C.QListWidget, cb C.in
 
 	virtualReturn := gofunc((&QListWidget{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qmimedata.cpp
+++ b/qt/gen_qmimedata.cpp
@@ -80,6 +80,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qmimedata.go
+++ b/qt/gen_qmimedata.go
@@ -402,12 +402,10 @@ func miqt_exec_callback_QMimeData_formats(self *C.QMimeData, cb C.intptr_t) C.st
 
 	virtualReturn := gofunc((&QMimeData{h: self}).callVirtualBase_Formats)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt/gen_qprogressbar.cpp
+++ b/qt/gen_qprogressbar.cpp
@@ -114,6 +114,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QProgressBar_text(this, handle__text);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qprogressbar.go
+++ b/qt/gen_qprogressbar.go
@@ -430,7 +430,6 @@ func miqt_exec_callback_QProgressBar_text(self *C.QProgressBar, cb C.intptr_t) C
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qsavefile.cpp
+++ b/qt/gen_qsavefile.cpp
@@ -68,6 +68,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSaveFile_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qsavefile.go
+++ b/qt/gen_qsavefile.go
@@ -300,7 +300,6 @@ func miqt_exec_callback_QSaveFile_fileName(self *C.QSaveFile, cb C.intptr_t) C.s
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qsortfilterproxymodel.cpp
+++ b/qt/gen_qsortfilterproxymodel.cpp
@@ -666,6 +666,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -725,6 +726,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qsortfilterproxymodel.go
+++ b/qt/gen_qsortfilterproxymodel.go
@@ -1851,7 +1851,6 @@ func miqt_exec_callback_QSortFilterProxyModel_match(self *C.QSortFilterProxyMode
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1949,12 +1948,10 @@ func miqt_exec_callback_QSortFilterProxyModel_mimeTypes(self *C.QSortFilterProxy
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2073,9 +2070,7 @@ func miqt_exec_callback_QSortFilterProxyModel_itemData(self *C.QSortFilterProxyM
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2317,9 +2312,7 @@ func miqt_exec_callback_QSortFilterProxyModel_roleNames(self *C.QSortFilterProxy
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qspinbox.cpp
+++ b/qt/gen_qspinbox.cpp
@@ -246,6 +246,7 @@ public:
 		int sigval1 = val;
 		struct miqt_string callback_return_value = miqt_exec_callback_QSpinBox_textFromValue(this, handle__textFromValue, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -2318,6 +2319,7 @@ public:
 		double sigval1 = val;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDoubleSpinBox_textFromValue(this, handle__textFromValue, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qspinbox.go
+++ b/qt/gen_qspinbox.go
@@ -584,7 +584,6 @@ func miqt_exec_callback_QSpinBox_textFromValue(self *C.QSpinBox, cb C.intptr_t, 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -2509,7 +2508,6 @@ func miqt_exec_callback_QDoubleSpinBox_textFromValue(self *C.QDoubleSpinBox, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qstandarditemmodel.cpp
+++ b/qt/gen_qstandarditemmodel.cpp
@@ -1221,6 +1221,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1441,6 +1446,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qstandarditemmodel.go
+++ b/qt/gen_qstandarditemmodel.go
@@ -2208,9 +2208,7 @@ func miqt_exec_callback_QStandardItemModel_itemData(self *C.QStandardItemModel, 
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2343,12 +2341,10 @@ func miqt_exec_callback_QStandardItemModel_mimeTypes(self *C.QStandardItemModel,
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2692,7 +2688,6 @@ func miqt_exec_callback_QStandardItemModel_match(self *C.QStandardItemModel, cb 
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -2766,9 +2761,7 @@ func miqt_exec_callback_QStandardItemModel_roleNames(self *C.QStandardItemModel,
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qstringlistmodel.cpp
+++ b/qt/gen_qstringlistmodel.cpp
@@ -431,6 +431,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -644,6 +649,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qstringlistmodel.go
+++ b/qt/gen_qstringlistmodel.go
@@ -912,9 +912,7 @@ func miqt_exec_callback_QStringListModel_itemData(self *C.QStringListModel, cb C
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1210,12 +1208,10 @@ func miqt_exec_callback_QStringListModel_mimeTypes(self *C.QStringListModel, cb 
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1551,7 +1547,6 @@ func miqt_exec_callback_QStringListModel_match(self *C.QStringListModel, cb C.in
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1625,9 +1620,7 @@ func miqt_exec_callback_QStringListModel_roleNames(self *C.QStringListModel, cb 
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qstyleditemdelegate.cpp
+++ b/qt/gen_qstyleditemdelegate.cpp
@@ -206,6 +206,7 @@ public:
 		QLocale* sigval2 = const_cast<QLocale*>(&locale_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QStyledItemDelegate_displayText(this, handle__displayText, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -330,6 +331,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qstyleditemdelegate.go
+++ b/qt/gen_qstyleditemdelegate.go
@@ -445,7 +445,6 @@ func miqt_exec_callback_QStyledItemDelegate_displayText(self *C.QStyledItemDeleg
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -632,7 +631,6 @@ func miqt_exec_callback_QStyledItemDelegate_paintingRoles(self *C.QStyledItemDel
 
 	virtualReturn := gofunc((&QStyledItemDelegate{h: self}).callVirtualBase_PaintingRoles)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt/gen_qtableview.cpp
+++ b/qt/gen_qtableview.cpp
@@ -454,6 +454,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qtableview.go
+++ b/qt/gen_qtableview.go
@@ -1237,7 +1237,6 @@ func miqt_exec_callback_QTableView_selectedIndexes(self *C.QTableView, cb C.intp
 
 	virtualReturn := gofunc((&QTableView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qtablewidget.cpp
+++ b/qt/gen_qtablewidget.cpp
@@ -707,6 +707,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1069,6 +1074,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qtablewidget.go
+++ b/qt/gen_qtablewidget.go
@@ -1869,12 +1869,10 @@ func miqt_exec_callback_QTableWidget_mimeTypes(self *C.QTableWidget, cb C.intptr
 
 	virtualReturn := gofunc((&QTableWidget{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2447,7 +2445,6 @@ func miqt_exec_callback_QTableWidget_selectedIndexes(self *C.QTableWidget, cb C.
 
 	virtualReturn := gofunc((&QTableWidget{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qtemporaryfile.cpp
+++ b/qt/gen_qtemporaryfile.cpp
@@ -70,6 +70,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QTemporaryFile_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qtemporaryfile.go
+++ b/qt/gen_qtemporaryfile.go
@@ -331,7 +331,6 @@ func miqt_exec_callback_QTemporaryFile_fileName(self *C.QTemporaryFile, cb C.int
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qtranslator.cpp
+++ b/qt/gen_qtranslator.cpp
@@ -52,6 +52,7 @@ public:
 		int sigval4 = n;
 		struct miqt_string callback_return_value = miqt_exec_callback_QTranslator_translate(this, handle__translate, sigval1, sigval2, sigval3, sigval4);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/gen_qtranslator.go
+++ b/qt/gen_qtranslator.go
@@ -390,7 +390,6 @@ func miqt_exec_callback_QTranslator_translate(self *C.QTranslator, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/gen_qtransposeproxymodel.cpp
+++ b/qt/gen_qtransposeproxymodel.cpp
@@ -782,6 +782,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -843,6 +848,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qtransposeproxymodel.go
+++ b/qt/gen_qtransposeproxymodel.go
@@ -873,9 +873,7 @@ func miqt_exec_callback_QTransposeProxyModel_itemData(self *C.QTransposeProxyMod
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1734,12 +1732,10 @@ func miqt_exec_callback_QTransposeProxyModel_mimeTypes(self *C.QTransposeProxyMo
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1838,7 +1834,6 @@ func miqt_exec_callback_QTransposeProxyModel_match(self *C.QTransposeProxyModel,
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1882,9 +1877,7 @@ func miqt_exec_callback_QTransposeProxyModel_roleNames(self *C.QTransposeProxyMo
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt/gen_qtreeview.cpp
+++ b/qt/gen_qtreeview.cpp
@@ -556,6 +556,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qtreeview.go
+++ b/qt/gen_qtreeview.go
@@ -1507,7 +1507,6 @@ func miqt_exec_callback_QTreeView_selectedIndexes(self *C.QTreeView, cb C.intptr
 
 	virtualReturn := gofunc((&QTreeView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qtreewidget.cpp
+++ b/qt/gen_qtreewidget.cpp
@@ -883,6 +883,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1326,6 +1331,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qtreewidget.go
+++ b/qt/gen_qtreewidget.go
@@ -1979,12 +1979,10 @@ func miqt_exec_callback_QTreeWidget_mimeTypes(self *C.QTreeWidget, cb C.intptr_t
 
 	virtualReturn := gofunc((&QTreeWidget{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2659,7 +2657,6 @@ func miqt_exec_callback_QTreeWidget_selectedIndexes(self *C.QTreeWidget, cb C.in
 
 	virtualReturn := gofunc((&QTreeWidget{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/gen_qundoview.cpp
+++ b/qt/gen_qundoview.cpp
@@ -670,6 +670,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/gen_qundoview.go
+++ b/qt/gen_qundoview.go
@@ -1395,7 +1395,6 @@ func miqt_exec_callback_QUndoView_selectedIndexes(self *C.QUndoView, cb C.intptr
 
 	virtualReturn := gofunc((&QUndoView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/multimedia/gen_qabstractvideosurface.cpp
+++ b/qt/multimedia/gen_qabstractvideosurface.cpp
@@ -66,6 +66,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<QVideoFrame::PixelFormat>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/multimedia/gen_qabstractvideosurface.go
+++ b/qt/multimedia/gen_qabstractvideosurface.go
@@ -374,7 +374,6 @@ func miqt_exec_callback_QAbstractVideoSurface_supportedPixelFormats(self *C.QAbs
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt/multimedia/gen_qaudiosystemplugin.cpp
+++ b/qt/multimedia/gen_qaudiosystemplugin.cpp
@@ -104,6 +104,11 @@ public:
 			QByteArray callback_return_value_arr_i_QByteArray(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QByteArray);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/multimedia/gen_qaudiosystemplugin.go
+++ b/qt/multimedia/gen_qaudiosystemplugin.go
@@ -356,7 +356,6 @@ func miqt_exec_callback_QAudioSystemPlugin_availableDevices(self *C.QAudioSystem
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_alias := C.struct_miqt_string{}
 		if len(virtualReturn[i]) > 0 {

--- a/qt/network/gen_qnetworkcookiejar.cpp
+++ b/qt/network/gen_qnetworkcookiejar.cpp
@@ -62,6 +62,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/network/gen_qnetworkcookiejar.go
+++ b/qt/network/gen_qnetworkcookiejar.go
@@ -299,7 +299,6 @@ func miqt_exec_callback_QNetworkCookieJar_cookiesForUrl(self *C.QNetworkCookieJa
 
 	virtualReturn := gofunc((&QNetworkCookieJar{h: self}).callVirtualBase_CookiesForUrl, slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QNetworkCookie)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/network/gen_qnetworkproxy.cpp
+++ b/qt/network/gen_qnetworkproxy.cpp
@@ -419,6 +419,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/network/gen_qnetworkproxy.go
+++ b/qt/network/gen_qnetworkproxy.go
@@ -754,7 +754,6 @@ func miqt_exec_callback_QNetworkProxyFactory_queryProxy(self *C.QNetworkProxyFac
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QNetworkProxy)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/pdf/gen_qpdfbookmarkmodel.cpp
+++ b/qt/pdf/gen_qpdfbookmarkmodel.cpp
@@ -372,6 +372,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -724,6 +729,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/pdf/gen_qpdfbookmarkmodel.go
+++ b/qt/pdf/gen_qpdfbookmarkmodel.go
@@ -783,9 +783,7 @@ func miqt_exec_callback_QPdfBookmarkModel_roleNames(self *C.QPdfBookmarkModel, c
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1008,9 +1006,7 @@ func miqt_exec_callback_QPdfBookmarkModel_itemData(self *C.QPdfBookmarkModel, cb
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1115,12 +1111,10 @@ func miqt_exec_callback_QPdfBookmarkModel_mimeTypes(self *C.QPdfBookmarkModel, c
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1673,7 +1667,6 @@ func miqt_exec_callback_QPdfBookmarkModel_match(self *C.QPdfBookmarkModel, cb C.
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt/pdf/gen_qpdfsearchmodel.cpp
+++ b/qt/pdf/gen_qpdfsearchmodel.cpp
@@ -376,6 +376,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -687,6 +692,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/pdf/gen_qpdfsearchmodel.go
+++ b/qt/pdf/gen_qpdfsearchmodel.go
@@ -642,9 +642,7 @@ func miqt_exec_callback_QPdfSearchModel_roleNames(self *C.QPdfSearchModel, cb C.
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1023,9 +1021,7 @@ func miqt_exec_callback_QPdfSearchModel_itemData(self *C.QPdfSearchModel, cb C.i
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1130,12 +1126,10 @@ func miqt_exec_callback_QPdfSearchModel_mimeTypes(self *C.QPdfSearchModel, cb C.
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1624,7 +1618,6 @@ func miqt_exec_callback_QPdfSearchModel_match(self *C.QPdfSearchModel, cb C.intp
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt/positioning/gen_qgeoareamonitorsource.cpp
+++ b/qt/positioning/gen_qgeoareamonitorsource.cpp
@@ -174,6 +174,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -196,6 +197,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/positioning/gen_qgeoareamonitorsource.go
+++ b/qt/positioning/gen_qgeoareamonitorsource.go
@@ -545,7 +545,6 @@ func miqt_exec_callback_QGeoAreaMonitorSource_activeMonitors(self *C.QGeoAreaMon
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QGeoAreaMonitorInfo)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -573,7 +572,6 @@ func miqt_exec_callback_QGeoAreaMonitorSource_activeMonitorsWithLookupArea(self 
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QGeoAreaMonitorInfo)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt/script/gen_qscriptclass.cpp
+++ b/qt/script/gen_qscriptclass.cpp
@@ -176,6 +176,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QScriptClass_name(this, handle__name);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/script/gen_qscriptclass.go
+++ b/qt/script/gen_qscriptclass.go
@@ -328,7 +328,6 @@ func miqt_exec_callback_QScriptClass_name(self *C.QScriptClass, cb C.intptr_t) C
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/script/gen_qscriptextensioninterface.cpp
+++ b/qt/script/gen_qscriptextensioninterface.cpp
@@ -64,6 +64,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/script/gen_qscriptextensioninterface.go
+++ b/qt/script/gen_qscriptextensioninterface.go
@@ -108,12 +108,10 @@ func miqt_exec_callback_QScriptExtensionInterface_keys(self *C.QScriptExtensionI
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt/script/gen_qscriptextensionplugin.cpp
+++ b/qt/script/gen_qscriptextensionplugin.cpp
@@ -58,6 +58,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/script/gen_qscriptextensionplugin.go
+++ b/qt/script/gen_qscriptextensionplugin.go
@@ -242,12 +242,10 @@ func miqt_exec_callback_QScriptExtensionPlugin_keys(self *C.QScriptExtensionPlug
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt/sql/gen_qsqldriver.cpp
+++ b/qt/sql/gen_qsqldriver.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -212,6 +217,7 @@ public:
 		bool sigval2 = trimStrings;
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_formatValue(this, handle__formatValue, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -238,6 +244,7 @@ public:
 		int sigval2 = static_cast<int>(type_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_escapeIdentifier(this, handle__escapeIdentifier, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -268,6 +275,7 @@ public:
 		bool sigval4 = preparedStatement;
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_sqlStatement(this, handle__sqlStatement, sigval1, sigval2, sigval3, sigval4);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -446,6 +454,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -497,6 +510,7 @@ public:
 		int sigval2 = static_cast<int>(type_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_stripDelimiters(this, handle__stripDelimiters, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/sql/gen_qsqldriver.go
+++ b/qt/sql/gen_qsqldriver.go
@@ -636,12 +636,10 @@ func miqt_exec_callback_QSqlDriver_tables(self *C.QSqlDriver, cb C.intptr_t, tab
 
 	virtualReturn := gofunc((&QSqlDriver{h: self}).callVirtualBase_Tables, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -754,7 +752,6 @@ func miqt_exec_callback_QSqlDriver_formatValue(self *C.QSqlDriver, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -796,7 +793,6 @@ func miqt_exec_callback_QSqlDriver_escapeIdentifier(self *C.QSqlDriver, cb C.int
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -842,7 +838,6 @@ func miqt_exec_callback_QSqlDriver_sqlStatement(self *C.QSqlDriver, cb C.intptr_
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1076,12 +1071,10 @@ func miqt_exec_callback_QSqlDriver_subscribedToNotifications(self *C.QSqlDriver,
 
 	virtualReturn := gofunc((&QSqlDriver{h: self}).callVirtualBase_SubscribedToNotifications)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1162,7 +1155,6 @@ func miqt_exec_callback_QSqlDriver_stripDelimiters(self *C.QSqlDriver, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/sql/gen_qsqlquerymodel.cpp
+++ b/qt/sql/gen_qsqlquerymodel.cpp
@@ -507,6 +507,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -741,6 +746,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/sql/gen_qsqlquerymodel.go
+++ b/qt/sql/gen_qsqlquerymodel.go
@@ -931,9 +931,7 @@ func miqt_exec_callback_QSqlQueryModel_roleNames(self *C.QSqlQueryModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1211,9 +1209,7 @@ func miqt_exec_callback_QSqlQueryModel_itemData(self *C.QSqlQueryModel, cb C.int
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1318,12 +1314,10 @@ func miqt_exec_callback_QSqlQueryModel_mimeTypes(self *C.QSqlQueryModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1694,7 +1688,6 @@ func miqt_exec_callback_QSqlQueryModel_match(self *C.QSqlQueryModel, cb C.intptr
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt/sql/gen_qsqlrelationaltablemodel.cpp
+++ b/qt/sql/gen_qsqlrelationaltablemodel.cpp
@@ -347,6 +347,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlRelationalTableModel_selectStatement(this, handle__selectStatement);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -400,6 +401,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlRelationalTableModel_orderByClause(this, handle__orderByClause);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -934,6 +936,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1109,6 +1116,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/sql/gen_qsqlrelationaltablemodel.go
+++ b/qt/sql/gen_qsqlrelationaltablemodel.go
@@ -993,7 +993,6 @@ func miqt_exec_callback_QSqlRelationalTableModel_selectStatement(self *C.QSqlRel
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1082,7 +1081,6 @@ func miqt_exec_callback_QSqlRelationalTableModel_orderByClause(self *C.QSqlRelat
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1673,9 +1671,7 @@ func miqt_exec_callback_QSqlRelationalTableModel_roleNames(self *C.QSqlRelationa
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1863,9 +1859,7 @@ func miqt_exec_callback_QSqlRelationalTableModel_itemData(self *C.QSqlRelational
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1970,12 +1964,10 @@ func miqt_exec_callback_QSqlRelationalTableModel_mimeTypes(self *C.QSqlRelationa
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2254,7 +2246,6 @@ func miqt_exec_callback_QSqlRelationalTableModel_match(self *C.QSqlRelationalTab
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt/sql/gen_qsqltablemodel.cpp
+++ b/qt/sql/gen_qsqltablemodel.cpp
@@ -522,6 +522,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlTableModel_orderByClause(this, handle__orderByClause);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -538,6 +539,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlTableModel_selectStatement(this, handle__selectStatement);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -834,6 +836,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1009,6 +1016,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/sql/gen_qsqltablemodel.go
+++ b/qt/sql/gen_qsqltablemodel.go
@@ -1454,7 +1454,6 @@ func miqt_exec_callback_QSqlTableModel_orderByClause(self *C.QSqlTableModel, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1485,7 +1484,6 @@ func miqt_exec_callback_QSqlTableModel_selectStatement(self *C.QSqlTableModel, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1703,9 +1701,7 @@ func miqt_exec_callback_QSqlTableModel_roleNames(self *C.QSqlTableModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1893,9 +1889,7 @@ func miqt_exec_callback_QSqlTableModel_itemData(self *C.QSqlTableModel, cb C.int
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2000,12 +1994,10 @@ func miqt_exec_callback_QSqlTableModel_mimeTypes(self *C.QSqlTableModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2284,7 +2276,6 @@ func miqt_exec_callback_QSqlTableModel_match(self *C.QSqlTableModel, cb C.intptr
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt/webengine/gen_qwebenginepage.cpp
+++ b/qt/webengine/gen_qwebenginepage.cpp
@@ -205,6 +205,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/webengine/gen_qwebenginepage.go
+++ b/qt/webengine/gen_qwebenginepage.go
@@ -1475,12 +1475,10 @@ func miqt_exec_callback_QWebEnginePage_chooseFiles(self *C.QWebEnginePage, cb C.
 
 	virtualReturn := gofunc((&QWebEnginePage{h: self}).callVirtualBase_ChooseFiles, slotval1, slotval2, slotval3)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt/webkit/gen_qwebpage.cpp
+++ b/qt/webkit/gen_qwebpage.cpp
@@ -313,6 +313,7 @@ public:
 		struct miqt_string sigval2 = oldFile_ms;
 		struct miqt_string callback_return_value = miqt_exec_callback_QWebPage_chooseFile(this, handle__chooseFile, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -414,6 +415,7 @@ public:
 		QUrl* sigval1 = const_cast<QUrl*>(&url_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QWebPage_userAgentForUrl(this, handle__userAgentForUrl, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt/webkit/gen_qwebpage.go
+++ b/qt/webkit/gen_qwebpage.go
@@ -1636,7 +1636,6 @@ func miqt_exec_callback_QWebPage_chooseFile(self *C.QWebPage, cb C.intptr_t, ori
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1785,7 +1784,6 @@ func miqt_exec_callback_QWebPage_userAgentForUrl(self *C.QWebPage, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt/webkit/gen_qwebpluginfactory.cpp
+++ b/qt/webkit/gen_qwebpluginfactory.cpp
@@ -61,6 +61,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt/webkit/gen_qwebpluginfactory.go
+++ b/qt/webkit/gen_qwebpluginfactory.go
@@ -260,7 +260,6 @@ func miqt_exec_callback_QWebPluginFactory_plugins(self *C.QWebPluginFactory, cb 
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QWebPluginFactory__Plugin)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/designer/gen_abstractintegration.cpp
+++ b/qt6/designer/gen_abstractintegration.cpp
@@ -132,6 +132,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegrationInterface_headerSuffix(this, handle__headerSuffix);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -235,6 +236,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegrationInterface_contextHelpId(this, handle__contextHelpId);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -1261,6 +1263,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegration_headerSuffix(this, handle__headerSuffix);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -1431,6 +1434,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerIntegration_contextHelpId(this, handle__contextHelpId);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/designer/gen_abstractintegration.go
+++ b/qt6/designer/gen_abstractintegration.go
@@ -598,7 +598,6 @@ func miqt_exec_callback_QDesignerIntegrationInterface_headerSuffix(self *C.QDesi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -741,7 +740,6 @@ func miqt_exec_callback_QDesignerIntegrationInterface_contextHelpId(self *C.QDes
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1449,7 +1447,6 @@ func miqt_exec_callback_QDesignerIntegration_headerSuffix(self *C.QDesignerInteg
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1722,7 +1719,6 @@ func miqt_exec_callback_QDesignerIntegration_contextHelpId(self *C.QDesignerInte
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/designer/gen_abstractmetadatabase.cpp
+++ b/qt6/designer/gen_abstractmetadatabase.cpp
@@ -60,6 +60,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerMetaDataBaseItemInterface_name(this, handle__name);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -100,6 +101,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(callback_return_value_arr[i]);
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -336,6 +338,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(callback_return_value_arr[i]);
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/designer/gen_abstractmetadatabase.go
+++ b/qt6/designer/gen_abstractmetadatabase.go
@@ -113,7 +113,6 @@ func miqt_exec_callback_QDesignerMetaDataBaseItemInterface_name(self *C.QDesigne
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -157,7 +156,6 @@ func miqt_exec_callback_QDesignerMetaDataBaseItemInterface_tabOrder(self *C.QDes
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QWidget)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QWidget)(virtualReturn[i].UnsafePointer())
 	}
@@ -513,7 +511,6 @@ func miqt_exec_callback_QDesignerMetaDataBaseInterface_objects(self *C.QDesigner
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QObject)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QObject)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/designer/gen_abstractoptionspage.cpp
+++ b/qt6/designer/gen_abstractoptionspage.cpp
@@ -36,6 +36,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerOptionsPageInterface_name(this, handle__name);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/designer/gen_abstractoptionspage.go
+++ b/qt6/designer/gen_abstractoptionspage.go
@@ -89,7 +89,6 @@ func miqt_exec_callback_QDesignerOptionsPageInterface_name(self *C.QDesignerOpti
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/designer/gen_abstractpropertyeditor.cpp
+++ b/qt6/designer/gen_abstractpropertyeditor.cpp
@@ -162,6 +162,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerPropertyEditorInterface_currentPropertyName(this, handle__currentPropertyName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/designer/gen_abstractpropertyeditor.go
+++ b/qt6/designer/gen_abstractpropertyeditor.go
@@ -369,7 +369,6 @@ func miqt_exec_callback_QDesignerPropertyEditorInterface_currentPropertyName(sel
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/designer/gen_abstractresourcebrowser.cpp
+++ b/qt6/designer/gen_abstractresourcebrowser.cpp
@@ -137,6 +137,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerResourceBrowserInterface_currentPath(this, handle__currentPath);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/designer/gen_abstractresourcebrowser.go
+++ b/qt6/designer/gen_abstractresourcebrowser.go
@@ -335,7 +335,6 @@ func miqt_exec_callback_QDesignerResourceBrowserInterface_currentPath(self *C.QD
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/designer/gen_abstractwidgetbox.cpp
+++ b/qt6/designer/gen_abstractwidgetbox.cpp
@@ -295,6 +295,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetBoxInterface_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/designer/gen_abstractwidgetbox.go
+++ b/qt6/designer/gen_abstractwidgetbox.go
@@ -562,7 +562,6 @@ func miqt_exec_callback_QDesignerWidgetBoxInterface_fileName(self *C.QDesignerWi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/designer/gen_abstractwidgetdatabase.cpp
+++ b/qt6/designer/gen_abstractwidgetdatabase.cpp
@@ -84,6 +84,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_name(this, handle__name);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -119,6 +120,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_group(this, handle__group);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -154,6 +156,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_toolTip(this, handle__toolTip);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -189,6 +192,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_whatsThis(this, handle__whatsThis);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -224,6 +228,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_includeFile(this, handle__includeFile);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -369,6 +374,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_pluginPath(this, handle__pluginPath);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -431,6 +437,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_extends(this, handle__extends);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -494,6 +501,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/designer/gen_abstractwidgetdatabase.go
+++ b/qt6/designer/gen_abstractwidgetdatabase.go
@@ -239,7 +239,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_name(self *C.QDesig
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -285,7 +284,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_group(self *C.QDesi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -331,7 +329,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_toolTip(self *C.QDe
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -377,7 +374,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_whatsThis(self *C.Q
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -423,7 +419,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_includeFile(self *C
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -625,7 +620,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_pluginPath(self *C.
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -710,7 +704,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_extends(self *C.QDe
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -782,7 +775,6 @@ func miqt_exec_callback_QDesignerWidgetDataBaseItemInterface_defaultPropertyValu
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QVariant)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/designer/gen_layoutdecoration.cpp
+++ b/qt6/designer/gen_layoutdecoration.cpp
@@ -56,6 +56,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(callback_return_value_arr[i]);
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/designer/gen_layoutdecoration.go
+++ b/qt6/designer/gen_layoutdecoration.go
@@ -174,7 +174,6 @@ func miqt_exec_callback_QDesignerLayoutDecorationExtension_widgets(self *C.QDesi
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QWidget)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QWidget)(virtualReturn[i].UnsafePointer())
 	}
@@ -309,9 +308,7 @@ func miqt_exec_callback_QDesignerLayoutDecorationExtension_currentCell(self *C.Q
 
 	virtualReturn := gofunc()
 	virtualReturn_First_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8)))
-	defer C.free(unsafe.Pointer(virtualReturn_First_CArray))
 	virtualReturn_Second_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8)))
-	defer C.free(unsafe.Pointer(virtualReturn_Second_CArray))
 	virtualReturn_First_CArray[0] = (C.int)(virtualReturn.First)
 	virtualReturn_Second_CArray[0] = (C.int)(virtualReturn.Second)
 	virtualReturn_pair := C.struct_miqt_map{

--- a/qt6/designer/gen_membersheet.cpp
+++ b/qt6/designer/gen_membersheet.cpp
@@ -82,6 +82,7 @@ public:
 		int sigval1 = index;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerMemberSheetExtension_memberName(this, handle__memberName, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -97,6 +98,7 @@ public:
 		int sigval1 = index;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerMemberSheetExtension_memberGroup(this, handle__memberGroup, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -205,6 +207,7 @@ public:
 		int sigval1 = index;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerMemberSheetExtension_declaredInClass(this, handle__declaredInClass, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -220,6 +223,7 @@ public:
 		int sigval1 = index;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerMemberSheetExtension_signature(this, handle__signature, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -241,6 +245,11 @@ public:
 			QByteArray callback_return_value_arr_i_QByteArray(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QByteArray);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -262,6 +271,11 @@ public:
 			QByteArray callback_return_value_arr_i_QByteArray(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QByteArray);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/designer/gen_membersheet.go
+++ b/qt6/designer/gen_membersheet.go
@@ -210,7 +210,6 @@ func miqt_exec_callback_QDesignerMemberSheetExtension_memberName(self *C.QDesign
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -236,7 +235,6 @@ func miqt_exec_callback_QDesignerMemberSheetExtension_memberGroup(self *C.QDesig
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -397,7 +395,6 @@ func miqt_exec_callback_QDesignerMemberSheetExtension_declaredInClass(self *C.QD
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -423,7 +420,6 @@ func miqt_exec_callback_QDesignerMemberSheetExtension_signature(self *C.QDesigne
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -447,7 +443,6 @@ func miqt_exec_callback_QDesignerMemberSheetExtension_parameterTypes(self *C.QDe
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_alias := C.struct_miqt_string{}
 		if len(virtualReturn[i]) > 0 {
@@ -482,7 +477,6 @@ func miqt_exec_callback_QDesignerMemberSheetExtension_parameterNames(self *C.QDe
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_alias := C.struct_miqt_string{}
 		if len(virtualReturn[i]) > 0 {

--- a/qt6/designer/gen_propertysheet.cpp
+++ b/qt6/designer/gen_propertysheet.cpp
@@ -83,6 +83,7 @@ public:
 		int sigval1 = index;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerPropertySheetExtension_propertyName(this, handle__propertyName, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -98,6 +99,7 @@ public:
 		int sigval1 = index;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDesignerPropertySheetExtension_propertyGroup(this, handle__propertyGroup, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/designer/gen_propertysheet.go
+++ b/qt6/designer/gen_propertysheet.go
@@ -197,7 +197,6 @@ func miqt_exec_callback_QDesignerPropertySheetExtension_propertyName(self *C.QDe
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -223,7 +222,6 @@ func miqt_exec_callback_QDesignerPropertySheetExtension_propertyGroup(self *C.QD
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/designer/gen_taskmenu.cpp
+++ b/qt6/designer/gen_taskmenu.cpp
@@ -52,6 +52,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(callback_return_value_arr[i]);
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/designer/gen_taskmenu.go
+++ b/qt6/designer/gen_taskmenu.go
@@ -107,7 +107,6 @@ func miqt_exec_callback_QDesignerTaskMenuExtension_taskActions(self *C.QDesigner
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QAction)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QAction)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/gen_qabstractfileiconprovider.cpp
+++ b/qt6/gen_qabstractfileiconprovider.cpp
@@ -76,6 +76,7 @@ public:
 		QFileInfo* sigval1 = const_cast<QFileInfo*>(&param1_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QAbstractFileIconProvider_type(this, handle__type, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qabstractfileiconprovider.go
+++ b/qt6/gen_qabstractfileiconprovider.go
@@ -185,7 +185,6 @@ func miqt_exec_callback_QAbstractFileIconProvider_type(self *C.QAbstractFileIcon
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qabstractitemdelegate.cpp
+++ b/qt6/gen_qabstractitemdelegate.cpp
@@ -264,6 +264,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qabstractitemdelegate.go
+++ b/qt6/gen_qabstractitemdelegate.go
@@ -592,7 +592,6 @@ func miqt_exec_callback_QAbstractItemDelegate_paintingRoles(self *C.QAbstractIte
 
 	virtualReturn := gofunc((&QAbstractItemDelegate{h: self}).callVirtualBase_PaintingRoles)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt6/gen_qabstractitemmodel.cpp
+++ b/qt6/gen_qabstractitemmodel.cpp
@@ -747,6 +747,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1099,6 +1104,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -3318,6 +3324,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -3629,6 +3640,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -5182,6 +5194,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -5493,6 +5510,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qabstractitemmodel.go
+++ b/qt6/gen_qabstractitemmodel.go
@@ -1817,9 +1817,7 @@ func miqt_exec_callback_QAbstractItemModel_itemData(self *C.QAbstractItemModel, 
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1952,12 +1950,10 @@ func miqt_exec_callback_QAbstractItemModel_mimeTypes(self *C.QAbstractItemModel,
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2510,7 +2506,6 @@ func miqt_exec_callback_QAbstractItemModel_match(self *C.QAbstractItemModel, cb 
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -2584,9 +2579,7 @@ func miqt_exec_callback_QAbstractItemModel_roleNames(self *C.QAbstractItemModel,
 
 	virtualReturn := gofunc((&QAbstractItemModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -3990,9 +3983,7 @@ func miqt_exec_callback_QAbstractTableModel_itemData(self *C.QAbstractTableModel
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -4125,12 +4116,10 @@ func miqt_exec_callback_QAbstractTableModel_mimeTypes(self *C.QAbstractTableMode
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -4619,7 +4608,6 @@ func miqt_exec_callback_QAbstractTableModel_match(self *C.QAbstractTableModel, c
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -4693,9 +4681,7 @@ func miqt_exec_callback_QAbstractTableModel_roleNames(self *C.QAbstractTableMode
 
 	virtualReturn := gofunc((&QAbstractTableModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -5782,9 +5768,7 @@ func miqt_exec_callback_QAbstractListModel_itemData(self *C.QAbstractListModel, 
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -5917,12 +5901,10 @@ func miqt_exec_callback_QAbstractListModel_mimeTypes(self *C.QAbstractListModel,
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -6411,7 +6393,6 @@ func miqt_exec_callback_QAbstractListModel_match(self *C.QAbstractListModel, cb 
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -6485,9 +6466,7 @@ func miqt_exec_callback_QAbstractListModel_roleNames(self *C.QAbstractListModel,
 
 	virtualReturn := gofunc((&QAbstractListModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt6/gen_qabstractitemview.cpp
+++ b/qt6/gen_qabstractitemview.cpp
@@ -803,6 +803,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qabstractitemview.go
+++ b/qt6/gen_qabstractitemview.go
@@ -1864,7 +1864,6 @@ func miqt_exec_callback_QAbstractItemView_selectedIndexes(self *C.QAbstractItemV
 
 	virtualReturn := gofunc((&QAbstractItemView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qabstractproxymodel.cpp
+++ b/qt6/gen_qabstractproxymodel.cpp
@@ -598,6 +598,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -876,6 +881,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qabstractproxymodel.go
+++ b/qt6/gen_qabstractproxymodel.go
@@ -930,9 +930,7 @@ func miqt_exec_callback_QAbstractProxyModel_itemData(self *C.QAbstractProxyModel
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1477,12 +1475,10 @@ func miqt_exec_callback_QAbstractProxyModel_mimeTypes(self *C.QAbstractProxyMode
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1575,9 +1571,7 @@ func miqt_exec_callback_QAbstractProxyModel_roleNames(self *C.QAbstractProxyMode
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1933,7 +1927,6 @@ func miqt_exec_callback_QAbstractProxyModel_match(self *C.QAbstractProxyModel, c
 
 	virtualReturn := gofunc((&QAbstractProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qcolumnview.cpp
+++ b/qt6/gen_qcolumnview.cpp
@@ -887,6 +887,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qcolumnview.go
+++ b/qt6/gen_qcolumnview.go
@@ -1610,7 +1610,6 @@ func miqt_exec_callback_QColumnView_selectedIndexes(self *C.QColumnView, cb C.in
 
 	virtualReturn := gofunc((&QColumnView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qcompleter.cpp
+++ b/qt6/gen_qcompleter.cpp
@@ -64,6 +64,7 @@ public:
 		QModelIndex* sigval1 = const_cast<QModelIndex*>(&index_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QCompleter_pathFromIndex(this, handle__pathFromIndex, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -94,6 +95,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qcompleter.go
+++ b/qt6/gen_qcompleter.go
@@ -507,7 +507,6 @@ func miqt_exec_callback_QCompleter_pathFromIndex(self *C.QCompleter, cb C.intptr
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -553,12 +552,10 @@ func miqt_exec_callback_QCompleter_splitPath(self *C.QCompleter, cb C.intptr_t, 
 
 	virtualReturn := gofunc((&QCompleter{h: self}).callVirtualBase_SplitPath, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt6/gen_qconcatenatetablesproxymodel.cpp
+++ b/qt6/gen_qconcatenatetablesproxymodel.cpp
@@ -308,6 +308,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -738,6 +743,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qconcatenatetablesproxymodel.go
+++ b/qt6/gen_qconcatenatetablesproxymodel.go
@@ -683,9 +683,7 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_itemData(self *C.QConcatena
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -972,12 +970,10 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_mimeTypes(self *C.QConcaten
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1656,7 +1652,6 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_match(self *C.QConcatenateT
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1700,9 +1695,7 @@ func miqt_exec_callback_QConcatenateTablesProxyModel_roleNames(self *C.QConcaten
 
 	virtualReturn := gofunc((&QConcatenateTablesProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt6/gen_qdatetimeedit.cpp
+++ b/qt6/gen_qdatetimeedit.cpp
@@ -456,6 +456,7 @@ public:
 		QDateTime* sigval1 = const_cast<QDateTime*>(&dt_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QDateTimeEdit_textFromDateTime(this, handle__textFromDateTime, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -2668,6 +2669,7 @@ public:
 		QDateTime* sigval1 = const_cast<QDateTime*>(&dt_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QTimeEdit_textFromDateTime(this, handle__textFromDateTime, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -4621,6 +4623,7 @@ public:
 		QDateTime* sigval1 = const_cast<QDateTime*>(&dt_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QDateEdit_textFromDateTime(this, handle__textFromDateTime, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qdatetimeedit.go
+++ b/qt6/gen_qdatetimeedit.go
@@ -943,7 +943,6 @@ func miqt_exec_callback_QDateTimeEdit_textFromDateTime(self *C.QDateTimeEdit, cb
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -2721,7 +2720,6 @@ func miqt_exec_callback_QTimeEdit_textFromDateTime(self *C.QTimeEdit, cb C.intpt
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -4499,7 +4497,6 @@ func miqt_exec_callback_QDateEdit_textFromDateTime(self *C.QDateEdit, cb C.intpt
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qfile.cpp
+++ b/qt6/gen_qfile.cpp
@@ -72,6 +72,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QFile_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qfile.go
+++ b/qt6/gen_qfile.go
@@ -453,7 +453,6 @@ func miqt_exec_callback_QFile_fileName(self *C.QFile, cb C.intptr_t) C.struct_mi
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qfileiconprovider.cpp
+++ b/qt6/gen_qfileiconprovider.cpp
@@ -77,6 +77,7 @@ public:
 		QFileInfo* sigval1 = const_cast<QFileInfo*>(&param1_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QFileIconProvider_type(this, handle__type, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qfileiconprovider.go
+++ b/qt6/gen_qfileiconprovider.go
@@ -156,7 +156,6 @@ func miqt_exec_callback_QFileIconProvider_type(self *C.QFileIconProvider, cb C.i
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qfilesystemmodel.cpp
+++ b/qt6/gen_qfilesystemmodel.cpp
@@ -353,6 +353,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -784,6 +789,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qfilesystemmodel.go
+++ b/qt6/gen_qfilesystemmodel.go
@@ -1294,12 +1294,10 @@ func miqt_exec_callback_QFileSystemModel_mimeTypes(self *C.QFileSystemModel, cb 
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1445,9 +1443,7 @@ func miqt_exec_callback_QFileSystemModel_roleNames(self *C.QFileSystemModel, cb 
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1596,9 +1592,7 @@ func miqt_exec_callback_QFileSystemModel_itemData(self *C.QFileSystemModel, cb C
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2032,7 +2026,6 @@ func miqt_exec_callback_QFileSystemModel_match(self *C.QFileSystemModel, cb C.in
 
 	virtualReturn := gofunc((&QFileSystemModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qheaderview.cpp
+++ b/qt6/gen_qheaderview.cpp
@@ -1070,6 +1070,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qheaderview.go
+++ b/qt6/gen_qheaderview.go
@@ -2391,7 +2391,6 @@ func miqt_exec_callback_QHeaderView_selectedIndexes(self *C.QHeaderView, cb C.in
 
 	virtualReturn := gofunc((&QHeaderView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qiconengine.cpp
+++ b/qt6/gen_qiconengine.cpp
@@ -171,6 +171,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QIconEngine_key(this, handle__key);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -245,6 +246,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -261,6 +263,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QIconEngine_iconName(this, handle__iconName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qiconengine.go
+++ b/qt6/gen_qiconengine.go
@@ -326,7 +326,6 @@ func miqt_exec_callback_QIconEngine_key(self *C.QIconEngine, cb C.intptr_t) C.st
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -441,7 +440,6 @@ func miqt_exec_callback_QIconEngine_availableSizes(self *C.QIconEngine, cb C.int
 
 	virtualReturn := gofunc((&QIconEngine{h: self}).callVirtualBase_AvailableSizes, slotval1, slotval2)
 	virtualReturn_CArray := (*[0xffff]*C.QSize)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -476,7 +474,6 @@ func miqt_exec_callback_QIconEngine_iconName(self *C.QIconEngine, cb C.intptr_t)
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qidentityproxymodel.cpp
+++ b/qt6/gen_qidentityproxymodel.cpp
@@ -323,6 +323,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -835,6 +836,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qidentityproxymodel.go
+++ b/qt6/gen_qidentityproxymodel.go
@@ -939,7 +939,6 @@ func miqt_exec_callback_QIdentityProxyModel_match(self *C.QIdentityProxyModel, c
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1292,9 +1291,7 @@ func miqt_exec_callback_QIdentityProxyModel_itemData(self *C.QIdentityProxyModel
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1769,12 +1766,10 @@ func miqt_exec_callback_QIdentityProxyModel_mimeTypes(self *C.QIdentityProxyMode
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1867,9 +1862,7 @@ func miqt_exec_callback_QIdentityProxyModel_roleNames(self *C.QIdentityProxyMode
 
 	virtualReturn := gofunc((&QIdentityProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt6/gen_qitemdelegate.cpp
+++ b/qt6/gen_qitemdelegate.cpp
@@ -397,6 +397,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qitemdelegate.go
+++ b/qt6/gen_qitemdelegate.go
@@ -779,7 +779,6 @@ func miqt_exec_callback_QItemDelegate_paintingRoles(self *C.QItemDelegate, cb C.
 
 	virtualReturn := gofunc((&QItemDelegate{h: self}).callVirtualBase_PaintingRoles)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt6/gen_qitemeditorfactory.cpp
+++ b/qt6/gen_qitemeditorfactory.cpp
@@ -73,6 +73,7 @@ public:
 		int sigval1 = userType;
 		struct miqt_string callback_return_value = miqt_exec_callback_QItemEditorFactory_valuePropertyName(this, handle__valuePropertyName, sigval1);
 		QByteArray callback_return_value_QByteArray(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QByteArray;
 	}
 

--- a/qt6/gen_qlistview.cpp
+++ b/qt6/gen_qlistview.cpp
@@ -668,6 +668,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qlistview.go
+++ b/qt6/gen_qlistview.go
@@ -1458,7 +1458,6 @@ func miqt_exec_callback_QListView_selectedIndexes(self *C.QListView, cb C.intptr
 
 	virtualReturn := gofunc((&QListView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qlistwidget.cpp
+++ b/qt6/gen_qlistwidget.cpp
@@ -700,6 +700,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1239,6 +1244,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qlistwidget.go
+++ b/qt6/gen_qlistwidget.go
@@ -1483,12 +1483,10 @@ func miqt_exec_callback_QListWidget_mimeTypes(self *C.QListWidget, cb C.intptr_t
 
 	virtualReturn := gofunc((&QListWidget{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2313,7 +2311,6 @@ func miqt_exec_callback_QListWidget_selectedIndexes(self *C.QListWidget, cb C.in
 
 	virtualReturn := gofunc((&QListWidget{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qmimedata.cpp
+++ b/qt6/gen_qmimedata.cpp
@@ -81,6 +81,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qmimedata.go
+++ b/qt6/gen_qmimedata.go
@@ -371,12 +371,10 @@ func miqt_exec_callback_QMimeData_formats(self *C.QMimeData, cb C.intptr_t) C.st
 
 	virtualReturn := gofunc((&QMimeData{h: self}).callVirtualBase_Formats)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt6/gen_qprogressbar.cpp
+++ b/qt6/gen_qprogressbar.cpp
@@ -116,6 +116,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QProgressBar_text(this, handle__text);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qprogressbar.go
+++ b/qt6/gen_qprogressbar.go
@@ -387,7 +387,6 @@ func miqt_exec_callback_QProgressBar_text(self *C.QProgressBar, cb C.intptr_t) C
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qsavefile.cpp
+++ b/qt6/gen_qsavefile.cpp
@@ -70,6 +70,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSaveFile_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qsavefile.go
+++ b/qt6/gen_qsavefile.go
@@ -269,7 +269,6 @@ func miqt_exec_callback_QSaveFile_fileName(self *C.QSaveFile, cb C.intptr_t) C.s
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qsortfilterproxymodel.cpp
+++ b/qt6/gen_qsortfilterproxymodel.cpp
@@ -670,6 +670,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -729,6 +730,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qsortfilterproxymodel.go
+++ b/qt6/gen_qsortfilterproxymodel.go
@@ -1842,7 +1842,6 @@ func miqt_exec_callback_QSortFilterProxyModel_match(self *C.QSortFilterProxyMode
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1940,12 +1939,10 @@ func miqt_exec_callback_QSortFilterProxyModel_mimeTypes(self *C.QSortFilterProxy
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2064,9 +2061,7 @@ func miqt_exec_callback_QSortFilterProxyModel_itemData(self *C.QSortFilterProxyM
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2264,9 +2259,7 @@ func miqt_exec_callback_QSortFilterProxyModel_roleNames(self *C.QSortFilterProxy
 
 	virtualReturn := gofunc((&QSortFilterProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt6/gen_qspinbox.cpp
+++ b/qt6/gen_qspinbox.cpp
@@ -247,6 +247,7 @@ public:
 		int sigval1 = val;
 		struct miqt_string callback_return_value = miqt_exec_callback_QSpinBox_textFromValue(this, handle__textFromValue, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -2287,6 +2288,7 @@ public:
 		double sigval1 = val;
 		struct miqt_string callback_return_value = miqt_exec_callback_QDoubleSpinBox_textFromValue(this, handle__textFromValue, sigval1);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qspinbox.go
+++ b/qt6/gen_qspinbox.go
@@ -514,7 +514,6 @@ func miqt_exec_callback_QSpinBox_textFromValue(self *C.QSpinBox, cb C.intptr_t, 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -2395,7 +2394,6 @@ func miqt_exec_callback_QDoubleSpinBox_textFromValue(self *C.QDoubleSpinBox, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qstandarditemmodel.cpp
+++ b/qt6/gen_qstandarditemmodel.cpp
@@ -1294,6 +1294,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1534,6 +1539,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qstandarditemmodel.go
+++ b/qt6/gen_qstandarditemmodel.go
@@ -1706,9 +1706,7 @@ func miqt_exec_callback_QStandardItemModel_roleNames(self *C.QStandardItemModel,
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2288,9 +2286,7 @@ func miqt_exec_callback_QStandardItemModel_itemData(self *C.QStandardItemModel, 
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -2423,12 +2419,10 @@ func miqt_exec_callback_QStandardItemModel_mimeTypes(self *C.QStandardItemModel,
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2806,7 +2800,6 @@ func miqt_exec_callback_QStandardItemModel_match(self *C.QStandardItemModel, cb 
 
 	virtualReturn := gofunc((&QStandardItemModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qstringlistmodel.cpp
+++ b/qt6/gen_qstringlistmodel.cpp
@@ -453,6 +453,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -666,6 +671,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qstringlistmodel.go
+++ b/qt6/gen_qstringlistmodel.go
@@ -901,9 +901,7 @@ func miqt_exec_callback_QStringListModel_itemData(self *C.QStringListModel, cb C
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1199,12 +1197,10 @@ func miqt_exec_callback_QStringListModel_mimeTypes(self *C.QStringListModel, cb 
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1540,7 +1536,6 @@ func miqt_exec_callback_QStringListModel_match(self *C.QStringListModel, cb C.in
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -1614,9 +1609,7 @@ func miqt_exec_callback_QStringListModel_roleNames(self *C.QStringListModel, cb 
 
 	virtualReturn := gofunc((&QStringListModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)

--- a/qt6/gen_qstyleditemdelegate.cpp
+++ b/qt6/gen_qstyleditemdelegate.cpp
@@ -206,6 +206,7 @@ public:
 		QLocale* sigval2 = const_cast<QLocale*>(&locale_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QStyledItemDelegate_displayText(this, handle__displayText, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -330,6 +331,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(static_cast<int>(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qstyleditemdelegate.go
+++ b/qt6/gen_qstyleditemdelegate.go
@@ -414,7 +414,6 @@ func miqt_exec_callback_QStyledItemDelegate_displayText(self *C.QStyledItemDeleg
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -601,7 +600,6 @@ func miqt_exec_callback_QStyledItemDelegate_paintingRoles(self *C.QStyledItemDel
 
 	virtualReturn := gofunc((&QStyledItemDelegate{h: self}).callVirtualBase_PaintingRoles)
 	virtualReturn_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (C.int)(virtualReturn[i])
 	}

--- a/qt6/gen_qtableview.cpp
+++ b/qt6/gen_qtableview.cpp
@@ -459,6 +459,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qtableview.go
+++ b/qt6/gen_qtableview.go
@@ -1137,7 +1137,6 @@ func miqt_exec_callback_QTableView_selectedIndexes(self *C.QTableView, cb C.intp
 
 	virtualReturn := gofunc((&QTableView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qtablewidget.cpp
+++ b/qt6/gen_qtablewidget.cpp
@@ -693,6 +693,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1057,6 +1062,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qtablewidget.go
+++ b/qt6/gen_qtablewidget.go
@@ -1698,12 +1698,10 @@ func miqt_exec_callback_QTableWidget_mimeTypes(self *C.QTableWidget, cb C.intptr
 
 	virtualReturn := gofunc((&QTableWidget{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2275,7 +2273,6 @@ func miqt_exec_callback_QTableWidget_selectedIndexes(self *C.QTableWidget, cb C.
 
 	virtualReturn := gofunc((&QTableWidget{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qtemporaryfile.cpp
+++ b/qt6/gen_qtemporaryfile.cpp
@@ -72,6 +72,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QTemporaryFile_fileName(this, handle__fileName);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qtemporaryfile.go
+++ b/qt6/gen_qtemporaryfile.go
@@ -288,7 +288,6 @@ func miqt_exec_callback_QTemporaryFile_fileName(self *C.QTemporaryFile, cb C.int
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qtranslator.cpp
+++ b/qt6/gen_qtranslator.cpp
@@ -52,6 +52,7 @@ public:
 		int sigval4 = n;
 		struct miqt_string callback_return_value = miqt_exec_callback_QTranslator_translate(this, handle__translate, sigval1, sigval2, sigval3, sigval4);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/gen_qtranslator.go
+++ b/qt6/gen_qtranslator.go
@@ -359,7 +359,6 @@ func miqt_exec_callback_QTranslator_translate(self *C.QTranslator, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/gen_qtransposeproxymodel.cpp
+++ b/qt6/gen_qtransposeproxymodel.cpp
@@ -804,6 +804,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -888,6 +893,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qtransposeproxymodel.go
+++ b/qt6/gen_qtransposeproxymodel.go
@@ -846,9 +846,7 @@ func miqt_exec_callback_QTransposeProxyModel_itemData(self *C.QTransposeProxyMod
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1735,12 +1733,10 @@ func miqt_exec_callback_QTransposeProxyModel_mimeTypes(self *C.QTransposeProxyMo
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1833,9 +1829,7 @@ func miqt_exec_callback_QTransposeProxyModel_roleNames(self *C.QTransposeProxyMo
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1899,7 +1893,6 @@ func miqt_exec_callback_QTransposeProxyModel_match(self *C.QTransposeProxyModel,
 
 	virtualReturn := gofunc((&QTransposeProxyModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qtreeview.cpp
+++ b/qt6/gen_qtreeview.cpp
@@ -559,6 +559,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qtreeview.go
+++ b/qt6/gen_qtreeview.go
@@ -1408,7 +1408,6 @@ func miqt_exec_callback_QTreeView_selectedIndexes(self *C.QTreeView, cb C.intptr
 
 	virtualReturn := gofunc((&QTreeView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qtreewidget.cpp
+++ b/qt6/gen_qtreewidget.cpp
@@ -877,6 +877,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1320,6 +1325,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qtreewidget.go
+++ b/qt6/gen_qtreewidget.go
@@ -1758,12 +1758,10 @@ func miqt_exec_callback_QTreeWidget_mimeTypes(self *C.QTreeWidget, cb C.intptr_t
 
 	virtualReturn := gofunc((&QTreeWidget{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2438,7 +2436,6 @@ func miqt_exec_callback_QTreeWidget_selectedIndexes(self *C.QTreeWidget, cb C.in
 
 	virtualReturn := gofunc((&QTreeWidget{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/gen_qundoview.cpp
+++ b/qt6/gen_qundoview.cpp
@@ -675,6 +675,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/gen_qundoview.go
+++ b/qt6/gen_qundoview.go
@@ -1299,7 +1299,6 @@ func miqt_exec_callback_QUndoView_selectedIndexes(self *C.QUndoView, cb C.intptr
 
 	virtualReturn := gofunc((&QUndoView{h: self}).callVirtualBase_SelectedIndexes)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/network/gen_qnetworkaccessmanager.cpp
+++ b/qt6/network/gen_qnetworkaccessmanager.cpp
@@ -74,6 +74,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/network/gen_qnetworkaccessmanager.go
+++ b/qt6/network/gen_qnetworkaccessmanager.go
@@ -651,12 +651,10 @@ func miqt_exec_callback_QNetworkAccessManager_supportedSchemes(self *C.QNetworkA
 
 	virtualReturn := gofunc((&QNetworkAccessManager{h: self}).callVirtualBase_SupportedSchemes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}

--- a/qt6/network/gen_qnetworkcookiejar.cpp
+++ b/qt6/network/gen_qnetworkcookiejar.cpp
@@ -62,6 +62,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/network/gen_qnetworkcookiejar.go
+++ b/qt6/network/gen_qnetworkcookiejar.go
@@ -268,7 +268,6 @@ func miqt_exec_callback_QNetworkCookieJar_cookiesForUrl(self *C.QNetworkCookieJa
 
 	virtualReturn := gofunc((&QNetworkCookieJar{h: self}).callVirtualBase_CookiesForUrl, slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QNetworkCookie)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/network/gen_qnetworkproxy.cpp
+++ b/qt6/network/gen_qnetworkproxy.cpp
@@ -371,6 +371,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/network/gen_qnetworkproxy.go
+++ b/qt6/network/gen_qnetworkproxy.go
@@ -668,7 +668,6 @@ func miqt_exec_callback_QNetworkProxyFactory_queryProxy(self *C.QNetworkProxyFac
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QNetworkProxy)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/pdf/gen_qpdfbookmarkmodel.cpp
+++ b/qt6/pdf/gen_qpdfbookmarkmodel.cpp
@@ -393,6 +393,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -745,6 +750,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/pdf/gen_qpdfbookmarkmodel.go
+++ b/qt6/pdf/gen_qpdfbookmarkmodel.go
@@ -708,9 +708,7 @@ func miqt_exec_callback_QPdfBookmarkModel_roleNames(self *C.QPdfBookmarkModel, c
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -933,9 +931,7 @@ func miqt_exec_callback_QPdfBookmarkModel_itemData(self *C.QPdfBookmarkModel, cb
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1068,12 +1064,10 @@ func miqt_exec_callback_QPdfBookmarkModel_mimeTypes(self *C.QPdfBookmarkModel, c
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1626,7 +1620,6 @@ func miqt_exec_callback_QPdfBookmarkModel_match(self *C.QPdfBookmarkModel, cb C.
 
 	virtualReturn := gofunc((&QPdfBookmarkModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/pdf/gen_qpdfsearchmodel.cpp
+++ b/qt6/pdf/gen_qpdfsearchmodel.cpp
@@ -397,6 +397,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -708,6 +713,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/pdf/gen_qpdfsearchmodel.go
+++ b/qt6/pdf/gen_qpdfsearchmodel.go
@@ -599,9 +599,7 @@ func miqt_exec_callback_QPdfSearchModel_roleNames(self *C.QPdfSearchModel, cb C.
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -980,9 +978,7 @@ func miqt_exec_callback_QPdfSearchModel_itemData(self *C.QPdfSearchModel, cb C.i
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1115,12 +1111,10 @@ func miqt_exec_callback_QPdfSearchModel_mimeTypes(self *C.QPdfSearchModel, cb C.
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1609,7 +1603,6 @@ func miqt_exec_callback_QPdfSearchModel_match(self *C.QPdfSearchModel, cb C.intp
 
 	virtualReturn := gofunc((&QPdfSearchModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/positioning/gen_qgeoareamonitorsource.cpp
+++ b/qt6/positioning/gen_qgeoareamonitorsource.cpp
@@ -177,6 +177,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -199,6 +200,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/positioning/gen_qgeoareamonitorsource.go
+++ b/qt6/positioning/gen_qgeoareamonitorsource.go
@@ -532,7 +532,6 @@ func miqt_exec_callback_QGeoAreaMonitorSource_activeMonitors(self *C.QGeoAreaMon
 
 	virtualReturn := gofunc()
 	virtualReturn_CArray := (*[0xffff]*C.QGeoAreaMonitorInfo)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}
@@ -560,7 +559,6 @@ func miqt_exec_callback_QGeoAreaMonitorSource_activeMonitorsWithLookupArea(self 
 
 	virtualReturn := gofunc(slotval1)
 	virtualReturn_CArray := (*[0xffff]*C.QGeoAreaMonitorInfo)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = virtualReturn[i].cPointer()
 	}

--- a/qt6/sql/gen_qsqldriver.cpp
+++ b/qt6/sql/gen_qsqldriver.cpp
@@ -146,6 +146,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -212,6 +217,7 @@ public:
 		bool sigval2 = trimStrings;
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_formatValue(this, handle__formatValue, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -238,6 +244,7 @@ public:
 		int sigval2 = static_cast<int>(type_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_escapeIdentifier(this, handle__escapeIdentifier, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -268,6 +275,7 @@ public:
 		bool sigval4 = preparedStatement;
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_sqlStatement(this, handle__sqlStatement, sigval1, sigval2, sigval3, sigval4);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -446,6 +454,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -497,6 +510,7 @@ public:
 		int sigval2 = static_cast<int>(type_ret);
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlDriver_stripDelimiters(this, handle__stripDelimiters, sigval1, sigval2);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 

--- a/qt6/sql/gen_qsqldriver.go
+++ b/qt6/sql/gen_qsqldriver.go
@@ -582,12 +582,10 @@ func miqt_exec_callback_QSqlDriver_tables(self *C.QSqlDriver, cb C.intptr_t, tab
 
 	virtualReturn := gofunc((&QSqlDriver{h: self}).callVirtualBase_Tables, slotval1)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -700,7 +698,6 @@ func miqt_exec_callback_QSqlDriver_formatValue(self *C.QSqlDriver, cb C.intptr_t
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -742,7 +739,6 @@ func miqt_exec_callback_QSqlDriver_escapeIdentifier(self *C.QSqlDriver, cb C.int
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -788,7 +784,6 @@ func miqt_exec_callback_QSqlDriver_sqlStatement(self *C.QSqlDriver, cb C.intptr_
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1022,12 +1017,10 @@ func miqt_exec_callback_QSqlDriver_subscribedToNotifications(self *C.QSqlDriver,
 
 	virtualReturn := gofunc((&QSqlDriver{h: self}).callVirtualBase_SubscribedToNotifications)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1108,7 +1101,6 @@ func miqt_exec_callback_QSqlDriver_stripDelimiters(self *C.QSqlDriver, cb C.intp
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 

--- a/qt6/sql/gen_qsqlquerymodel.cpp
+++ b/qt6/sql/gen_qsqlquerymodel.cpp
@@ -529,6 +529,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -763,6 +768,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/sql/gen_qsqlquerymodel.go
+++ b/qt6/sql/gen_qsqlquerymodel.go
@@ -888,9 +888,7 @@ func miqt_exec_callback_QSqlQueryModel_roleNames(self *C.QSqlQueryModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1168,9 +1166,7 @@ func miqt_exec_callback_QSqlQueryModel_itemData(self *C.QSqlQueryModel, cb C.int
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1303,12 +1299,10 @@ func miqt_exec_callback_QSqlQueryModel_mimeTypes(self *C.QSqlQueryModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -1679,7 +1673,6 @@ func miqt_exec_callback_QSqlQueryModel_match(self *C.QSqlQueryModel, cb C.intptr
 
 	virtualReturn := gofunc((&QSqlQueryModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/sql/gen_qsqlrelationaltablemodel.cpp
+++ b/qt6/sql/gen_qsqlrelationaltablemodel.cpp
@@ -351,6 +351,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlRelationalTableModel_selectStatement(this, handle__selectStatement);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -404,6 +405,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlRelationalTableModel_orderByClause(this, handle__orderByClause);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -956,6 +958,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1131,6 +1138,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/sql/gen_qsqlrelationaltablemodel.go
+++ b/qt6/sql/gen_qsqlrelationaltablemodel.go
@@ -950,7 +950,6 @@ func miqt_exec_callback_QSqlRelationalTableModel_selectStatement(self *C.QSqlRel
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1039,7 +1038,6 @@ func miqt_exec_callback_QSqlRelationalTableModel_orderByClause(self *C.QSqlRelat
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1658,9 +1656,7 @@ func miqt_exec_callback_QSqlRelationalTableModel_roleNames(self *C.QSqlRelationa
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1848,9 +1844,7 @@ func miqt_exec_callback_QSqlRelationalTableModel_itemData(self *C.QSqlRelational
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1955,12 +1949,10 @@ func miqt_exec_callback_QSqlRelationalTableModel_mimeTypes(self *C.QSqlRelationa
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2239,7 +2231,6 @@ func miqt_exec_callback_QSqlRelationalTableModel_match(self *C.QSqlRelationalTab
 
 	virtualReturn := gofunc((&QSqlRelationalTableModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/sql/gen_qsqltablemodel.cpp
+++ b/qt6/sql/gen_qsqltablemodel.cpp
@@ -544,6 +544,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlTableModel_orderByClause(this, handle__orderByClause);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -560,6 +561,7 @@ public:
 
 		struct miqt_string callback_return_value = miqt_exec_callback_QSqlTableModel_selectStatement(this, handle__selectStatement);
 		QString callback_return_value_QString = QString::fromUtf8(callback_return_value.data, callback_return_value.len);
+		free(callback_return_value.data);
 		return callback_return_value_QString;
 	}
 
@@ -856,6 +858,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 
@@ -1031,6 +1038,7 @@ public:
 		for(size_t i = 0; i < callback_return_value.len; ++i) {
 			callback_return_value_QList.push_back(*(callback_return_value_arr[i]));
 		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/sql/gen_qsqltablemodel.go
+++ b/qt6/sql/gen_qsqltablemodel.go
@@ -1443,7 +1443,6 @@ func miqt_exec_callback_QSqlTableModel_orderByClause(self *C.QSqlTableModel, cb 
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1474,7 +1473,6 @@ func miqt_exec_callback_QSqlTableModel_selectStatement(self *C.QSqlTableModel, c
 	virtualReturn_ms := C.struct_miqt_string{}
 	virtualReturn_ms.data = C.CString(virtualReturn)
 	virtualReturn_ms.len = C.size_t(len(virtualReturn))
-	defer C.free(unsafe.Pointer(virtualReturn_ms.data))
 
 	return virtualReturn_ms
 
@@ -1692,9 +1690,7 @@ func miqt_exec_callback_QSqlTableModel_roleNames(self *C.QSqlTableModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_RoleNames)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1882,9 +1878,7 @@ func miqt_exec_callback_QSqlTableModel_itemData(self *C.QSqlTableModel, cb C.int
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_ItemData, slotval1)
 	virtualReturn_Keys_CArray := (*[0xffff]C.int)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Keys_CArray))
 	virtualReturn_Values_CArray := (*[0xffff]*C.QVariant)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_Values_CArray))
 	virtualReturn_ctr := 0
 	for virtualReturn_k, virtualReturn_v := range virtualReturn {
 		virtualReturn_Keys_CArray[virtualReturn_ctr] = (C.int)(virtualReturn_k)
@@ -1989,12 +1983,10 @@ func miqt_exec_callback_QSqlTableModel_mimeTypes(self *C.QSqlTableModel, cb C.in
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_MimeTypes)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}
@@ -2273,7 +2265,6 @@ func miqt_exec_callback_QSqlTableModel_match(self *C.QSqlTableModel, cb C.intptr
 
 	virtualReturn := gofunc((&QSqlTableModel{h: self}).callVirtualBase_Match, slotval1, slotval2, slotval3, slotval4, slotval5)
 	virtualReturn_CArray := (*[0xffff]*C.QModelIndex)(C.malloc(C.size_t(8 * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_CArray[i] = (*C.QModelIndex)(virtualReturn[i].UnsafePointer())
 	}

--- a/qt6/webengine/gen_qwebenginepage.cpp
+++ b/qt6/webengine/gen_qwebenginepage.cpp
@@ -212,6 +212,11 @@ public:
 			QString callback_return_value_arr_i_QString = QString::fromUtf8(callback_return_value_arr[i].data, callback_return_value_arr[i].len);
 			callback_return_value_QList.push_back(callback_return_value_arr_i_QString);
 		}
+		struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
+		for(size_t i = 0; i < callback_return_value.len; ++i) {
+			free(callback_return_value_free_arr[i].data);
+		}
+		free(callback_return_value.data);
 		return callback_return_value_QList;
 	}
 

--- a/qt6/webengine/gen_qwebenginepage.go
+++ b/qt6/webengine/gen_qwebenginepage.go
@@ -1565,12 +1565,10 @@ func miqt_exec_callback_QWebEnginePage_chooseFiles(self *C.QWebEnginePage, cb C.
 
 	virtualReturn := gofunc((&QWebEnginePage{h: self}).callVirtualBase_ChooseFiles, slotval1, slotval2, slotval3)
 	virtualReturn_CArray := (*[0xffff]C.struct_miqt_string)(C.malloc(C.size_t(int(unsafe.Sizeof(C.struct_miqt_string{})) * len(virtualReturn))))
-	defer C.free(unsafe.Pointer(virtualReturn_CArray))
 	for i := range virtualReturn {
 		virtualReturn_i_ms := C.struct_miqt_string{}
 		virtualReturn_i_ms.data = C.CString(virtualReturn[i])
 		virtualReturn_i_ms.len = C.size_t(len(virtualReturn[i]))
-		defer C.free(unsafe.Pointer(virtualReturn_i_ms.data))
 		virtualReturn_CArray[i] = virtualReturn_i_ms
 	}
 	virtualReturn_ma := C.struct_miqt_array{len: C.size_t(len(virtualReturn)), data: unsafe.Pointer(virtualReturn_CArray)}


### PR DESCRIPTION
## In plain English

If you subclass a Qt virtual method in Go and that method returns a heap type
(a `string`, `[]string`, `QList<T>`, or a map), the binding frees the memory a
moment too early — so C++ reads memory that's already been freed. The most
visible symptom: a custom `QAbstractItemModel` in a `QTreeView` with
`InternalMove` drag-drop **crashes the instant you start a drag**
(`std::bad_alloc`). A `QStandardItemModel`-backed view is fine, because its drag
path is pure C++ with no Go callback.

The cause is a one-line lifetime mistake in the code generator: when a Go
callback hands its return value back to C++, the generated Go code adds a
`defer C.free(...)`. For a normal **argument** that's correct (free it after the
C call). For a **return value** it's wrong — the `defer` runs the moment the Go
callback returns, which is *before* C++ has copied the data out. C++ then reads
freed memory.

The fix moves the free from the wrong place to the right place. Two small,
coordinated changes:

1. **Stop freeing too early (Go side).** Don't emit the `defer C.free(...)` on
   the return value, so the memory survives until C++ has it.
2. **Free at the right time (C++ side).** In the generated C++ trampoline, free
   that memory *after* it's been copied into the real Qt type.

Change 1 alone stops the crash but would leak the memory; change 2 reclaims it.
Together: no crash, no leak. This is systemic — it covers every overridden
virtual that returns a heap type, not just `mimeTypes` (which is simply the one
the drag-drop path happens to call first).

---

## Details

### Reproduction

A custom `QAbstractItemModel` in a `QTreeView` with `InternalMove` drag-drop
crashes with `std::bad_alloc` / `SIGABRT` the moment a drag starts. Tested with
miqt v0.14.0 (qt6), Qt 6.11.1, Go 1.26, linux/amd64.

```go
package main

import (
	"os"
	"strconv"

	qt "github.com/mappu/miqt/qt6"
)

const reproMime = "application/x-repro-node"

type model struct {
	*qt.QAbstractItemModel
	n int
}

func newModel(n int) *model {
	m := &model{QAbstractItemModel: qt.NewQAbstractItemModel(), n: n}
	m.OnRowCount(m.rowCount)
	m.OnColumnCount(m.columnCount)
	m.OnIndex(m.index)
	m.OnParent(m.parent)
	m.OnData(m.data)
	m.OnFlags(m.flags)
	m.OnMimeTypes(m.mimeTypes)
	m.OnMimeData(m.mimeData)
	m.OnDropMimeData(m.dropMimeData)
	m.OnSupportedDropActions(m.supportedDropActions)
	return m
}

func (m *model) rowCount(parent *qt.QModelIndex) int {
	if parent.IsValid() {
		return 0
	}
	return m.n
}
func (m *model) columnCount(parent *qt.QModelIndex) int { return 1 }
func (m *model) index(row, col int, parent *qt.QModelIndex) *qt.QModelIndex {
	idx := m.CreateIndex2(row, col, uintptr(row+1))
	return &idx
}
func (m *model) parent(child *qt.QModelIndex) *qt.QModelIndex { return qt.NewQModelIndex() }
func (m *model) data(index *qt.QModelIndex, role int) *qt.QVariant {
	if role == int(qt.DisplayRole) && index.IsValid() {
		return qt.NewQVariant11("row " + strconv.FormatInt(int64(index.InternalId()), 10))
	}
	return qt.NewQVariant()
}
func (m *model) flags(super func(*qt.QModelIndex) qt.ItemFlag, index *qt.QModelIndex) qt.ItemFlag {
	if !index.IsValid() {
		return qt.ItemIsDropEnabled
	}
	return qt.ItemIsSelectable | qt.ItemIsEnabled | qt.ItemIsDragEnabled | qt.ItemIsDropEnabled
}
func (m *model) mimeTypes(super func() []string) []string { return []string{reproMime} }
func (m *model) supportedDropActions(super func() qt.DropAction) qt.DropAction {
	return qt.MoveAction
}
func (m *model) mimeData(super func([]qt.QModelIndex) *qt.QMimeData, indexes []qt.QModelIndex) *qt.QMimeData {
	md := qt.NewQMimeData()
	if len(indexes) > 0 {
		md.SetData(reproMime, []byte(strconv.FormatInt(int64(indexes[0].InternalId()), 10)))
	}
	return md
}
func (m *model) dropMimeData(super func(*qt.QMimeData, qt.DropAction, int, int, *qt.QModelIndex) bool, data *qt.QMimeData, action qt.DropAction, row, col int, parent *qt.QModelIndex) bool {
	return false
}

func main() {
	qt.NewQApplication(os.Args)
	view := qt.NewQTreeView2()
	view.SetModel(newModel(10).QAbstractItemModel)
	view.SetDragDropMode(qt.QAbstractItemView__InternalMove)
	view.Show()
	qt.QApplication_Exec()
}
```

Drag any row → crash.

### C++ backtrace (gdb `catch throw`)

```
#1 qBadAlloc()
#3 QString::fromUtf8(QByteArrayView)
#5 MiqtVirtualQAbstractItemModel::mimeTypes()
#7 QAbstractItemView::dragEnterEvent(QDragEnterEvent*)
...
#25 QDrag::exec → #26 QAbstractItemView::startDrag → #28 mouseMoveEvent
```

On drag-enter the view calls the model's `mimeTypes()`. The generated C++
trampoline reads the `miqt_array` of `miqt_string` returned by the Go callback
and does `QString::fromUtf8(arr[i].data, arr[i].len)` — but `arr[i].len` is
garbage (freed heap), so Qt throws `qBadAlloc`.

### Root cause

In `gen_qabstractitemmodel.go`, `miqt_exec_callback_QAbstractItemModel_mimeTypes`:

```go
virtualReturn := gofunc(...)                          // []string
virtualReturn_CArray := (*[...])(C.malloc(...))
defer C.free(unsafe.Pointer(virtualReturn_CArray))    // (a) runs on return
for i := range virtualReturn {
    ...
    virtualReturn_i_ms.data = C.CString(virtualReturn[i])
    virtualReturn_i_ms.len  = C.size_t(len(virtualReturn[i]))
    defer C.free(unsafe.Pointer(virtualReturn_i_ms.data)) // (b) runs on return
    ...
}
return virtualReturn_ma            // (a)/(b) free HERE, before C++ reads it
```

Generator origin: `cmd/genbindings/emitgo.go`, the virtual-callback emission
path reuses `emitParameterGo2CABIForwarding` to marshal the **return** value —
and that helper emits `defer C.free(...)`. That lifetime is correct for
arguments (freed after the C call returns) but a use-after-free for callback
return values (the C++ caller reads them after the Go callback has returned).

Systemic: every overridden virtual returning a heap CABI type — `string`,
`[]string`, `QList<T>`, maps — is affected. `mimeTypes` is just the one
exercised first by drag-enter.

### The fix

- **`emitgo.go`** — `stripDeferCFree()` removes the `defer C.free(...)` lines
  from the return-value marshaling, so the CABI memory outlives the Go
  callback's return.
- **`emitcabi.go`** — `emitCABI2CppFreeReturn()` frees that CABI memory in the
  C++ trampoline *after* copying it into the real Qt return type (each element's
  `data` + the top-level buffer), mirroring the heap cases of
  `emitCABI2CppForwarding`.

### Verification

- `go build ./cmd/genbindings` — passes.
- `go test ./cmd/genbindings -run TestStripDeferCFree` — passes (strips exactly
  the `defer C.free` lines, leaves the allocations intact).
- **Regenerated output** (ran the patched generator over qt6) — both sides are
  as intended:
  - `gen_qabstractitemmodel.go`: the `mimeTypes` callback now has **zero**
    `defer C.free` (was 2).
  - `gen_qabstractitemmodel.cpp`: the `mimeTypes` trampoline now frees after the
    copy —
    ```cpp
    // ... copy loop builds callback_return_value_QList ...
    struct miqt_string* callback_return_value_free_arr = static_cast<struct miqt_string*>(callback_return_value.data);
    for(size_t i = 0; i < callback_return_value.len; ++i) {
        free(callback_return_value_free_arr[i].data);
    }
    free(callback_return_value.data);
    return callback_return_value_QList;
    ```
- **Runtime:** with the equivalent change applied to the generated files, both
  the minimal repro and a real custom-model app drag/drop cleanly, with
  drag-reparent + save persisting correctly, and no leak.

### Note on regenerated files

This PR contains the **generator** change + a unit test; I haven't committed the
regenerated `gen_*` for the whole tree. My environment (Qt 6.11 + clang 22 vs
miqt's pinned Qt 6.9 + clang 18) needs allowlist tweaks for a clean full
regenerate, so I've left the committed-file regeneration to your CI /
`miqt-docker`. I did run a targeted regenerate of the affected file to confirm
the generator emits the correct output on both sides (shown above).
