### PR TITLE
ast: filter out field defaults

### DIFF
--- a/cmd/genbindings/clang2il.go
+++ b/cmd/genbindings/clang2il.go
@@ -69,7 +69,9 @@ func parseHeader(node *AstNode, addNamePrefix string, output *CppParsedHeader, m
 				parseHeader(inner, addNamePrefix+namespace+"::", output, matcher)
 			}
 		}
-
+	case "NamespaceAliasDecl":
+		// TODO Qt 6.8+
+		return
 	case "CXXRecordDecl":
 		if !matcher(node.file(), output.Filename) {
 			return

--- a/cmd/genbindings/clangfilter.go
+++ b/cmd/genbindings/clangfilter.go
@@ -38,7 +38,7 @@ func parseInner(ctx *ParseCtx, kind string) bool {
 	// Return false for all the kinds whose inner nodes we don't care about
 	// at all - this is a performance optimization
 	switch kind {
-	case "FieldDecl", "TranslationUnitDecl", "NamespaceDecl":
+	case "TranslationUnitDecl", "NamespaceDecl":
 		return true
 	case "CXXRecordDecl", "EnumDecl", "EnumConstantDecl": // methods, fields, elements etc
 		return true
@@ -56,7 +56,7 @@ func parseInner(ctx *ParseCtx, kind string) bool {
 	case "LinkageSpecDecl", "FunctionDecl", "AccessSpecDecl", "VarDecl",
 		"FileScopeAsmDecl", "FriendDecl", "UsingShadowDecl", "UsingDecl",
 		"StaticAssertDecl", "ElaboratedType", "FullComment", "ParagraphComment",
-		"EmptyDecl", "IndirectFieldDecl":
+		"EmptyDecl", "IndirectFieldDecl", "FieldDecl":
 		return false
 	case "ClassTemplateDecl", "TypeAliasTemplateDecl",
 		"ClassTemplateSpecializationDecl",


### PR DESCRIPTION
Gets rid of a bunch of pesky warnings - also, ignore namespace aliases (Qt 6.8 starts using these)