### PR TITLE
Ensure all packages set --std=c++11/17 automatically in cgo CXXFLAGS

### DIFF
--- a/.github/workflows/miqt.yml
+++ b/.github/workflows/miqt.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Run unit tests for cmd tasks
       run: make test-cmd
 
+    - name: Assert cflags files are up-to-date
+      run: cmd/lint-cflags-files.sh
+    
     - name: Rebuild binding source
       run: make genbindings
     

--- a/cmd/genbindings/config-libraries.go
+++ b/cmd/genbindings/config-libraries.go
@@ -99,6 +99,7 @@ func ProcessLibraries(clangBin, outDir, extraLibsDir string) {
 	)
 
 	// Qt 5 Network (2/3)
+	// n.b. This is here for parity with Qt 6, however, it generates zero files
 
 	generate(
 		"qt/network/sctp",

--- a/cmd/lint-cflags-files.sh
+++ b/cmd/lint-cflags-files.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Check that each Qt cgo package has the expected #cgo directives for that
+# version of Qt
+
+set -euo pipefail
+
+require_cflags() {
+	local dirname="$1"
+	local check="$2"
+	local status=0
+	
+	for d in $(find "${dirname}" -type d | sort); do
+	
+		# allowed exceptions:
+		if [[ $d =~ mainthread ]] ; then
+			continue
+		fi
+	
+		if [[ ! -f $d/cflags.go ]] ; then
+			echo "WARNING: Package $d missing cflags.go file" >&2
+			status=1
+		fi
+		
+		if ! grep -Fq "$check" "$d/cflags.go" ; then
+			echo "WARNING: Package $d missing expected '$check'" >&2
+			status=1
+		fi
+	done
+	
+	return $status
+}
+
+main() {
+	require_cflags qt '#cgo CXXFLAGS: -std=c++11'
+	require_cflags qt '#cgo CFLAGS: -std=gnu11'
+	require_cflags qt '#cgo pkg-config:'
+	
+	require_cflags qt6 '#cgo CXXFLAGS: -std=c++17'
+	require_cflags qt6 '#cgo pkg-config:'
+}
+
+main "$@"

--- a/qt/designer/cflags.go
+++ b/qt/designer/cflags.go
@@ -1,6 +1,8 @@
 package designer
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5UiPlugin Qt5Designer
 */
 import "C"

--- a/qt/mainthread/mainthread.go
+++ b/qt/mainthread/mainthread.go
@@ -1,12 +1,13 @@
 package mainthread
 
 import (
-	"sync"
 	"runtime/cgo"
+	"sync"
 )
 
 /*
 #cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5Core
 
 #include "mainthread.h"

--- a/qt/opengl/cflags.go
+++ b/qt/opengl/cflags.go
@@ -1,6 +1,8 @@
 package opengl
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5OpenGL
 */
 import "C"

--- a/qt/pdf/cflags.go
+++ b/qt/pdf/cflags.go
@@ -1,7 +1,8 @@
 package pdf
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5PdfWidgets
 */
 import "C"
-

--- a/qt/positioning/cflags.go
+++ b/qt/positioning/cflags.go
@@ -1,6 +1,8 @@
 package positioning
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5Positioning
 */
 import "C"

--- a/qt/printsupport/cflags.go
+++ b/qt/printsupport/cflags.go
@@ -1,6 +1,8 @@
 package printsupport
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5PrintSupport
 */
 import "C"

--- a/qt/script/cflags.go
+++ b/qt/script/cflags.go
@@ -1,6 +1,8 @@
 package script
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5Script
 */
 import "C"

--- a/qt/sql/cflags.go
+++ b/qt/sql/cflags.go
@@ -1,6 +1,8 @@
 package sql
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5Sql
 */
 import "C"

--- a/qt/svg/cflags.go
+++ b/qt/svg/cflags.go
@@ -1,6 +1,8 @@
 package svg
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5Svg
 */
 import "C"

--- a/qt/uiplugin/cflags.go
+++ b/qt/uiplugin/cflags.go
@@ -1,6 +1,8 @@
 package uiplugin
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5UiPlugin Qt5Designer
 */
 import "C"

--- a/qt/uitools/cflags.go
+++ b/qt/uitools/cflags.go
@@ -1,6 +1,8 @@
 package uitools
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5UiTools
 */
 import "C"

--- a/qt/webchannel/cflags.go
+++ b/qt/webchannel/cflags.go
@@ -1,6 +1,8 @@
 package webchannel
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5WebChannel
 */
 import "C"

--- a/qt/webengine/cflags.go
+++ b/qt/webengine/cflags.go
@@ -1,6 +1,8 @@
 package webengine
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5WebEngineWidgets
 */
 import "C"

--- a/qt/webkit/cflags.go
+++ b/qt/webkit/cflags.go
@@ -1,6 +1,8 @@
 package webkit
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5WebKitWidgets Qt5PrintSupport
 */
 import "C"

--- a/qt/websockets/cflags.go
+++ b/qt/websockets/cflags.go
@@ -1,7 +1,8 @@
 package websockets
 
 /*
+#cgo CXXFLAGS: -std=c++11
+#cgo CFLAGS: -std=gnu11
 #cgo pkg-config: Qt5WebSockets
 */
 import "C"
-

--- a/qt6/cbor/cflags.go
+++ b/qt6/cbor/cflags.go
@@ -1,6 +1,7 @@
 package cbor
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Core
 */
 import "C"

--- a/qt6/cflags.go
+++ b/qt6/cflags.go
@@ -1,6 +1,7 @@
 package qt6
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Widgets
 */
 import "C"

--- a/qt6/designer/cflags.go
+++ b/qt6/designer/cflags.go
@@ -1,6 +1,7 @@
 package designer
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6UiPlugin Qt6Designer
 */
 import "C"

--- a/qt6/multimedia/cflags.go
+++ b/qt6/multimedia/cflags.go
@@ -1,6 +1,7 @@
 package multimedia
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6MultimediaWidgets
 */
 import "C"

--- a/qt6/network/cflags.go
+++ b/qt6/network/cflags.go
@@ -1,6 +1,7 @@
 package network
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Network
 */
 import "C"

--- a/qt6/network/dtls/cflags.go
+++ b/qt6/network/dtls/cflags.go
@@ -1,6 +1,7 @@
 package dtls
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Network
 */
 import "C"

--- a/qt6/network/sctp/cflags.go
+++ b/qt6/network/sctp/cflags.go
@@ -1,6 +1,7 @@
 package sctp
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Network
 */
 import "C"

--- a/qt6/pdf/cflags.go
+++ b/qt6/pdf/cflags.go
@@ -1,7 +1,7 @@
 package pdf
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6PdfWidgets
 */
 import "C"
-

--- a/qt6/positioning/cflags.go
+++ b/qt6/positioning/cflags.go
@@ -1,6 +1,7 @@
 package positioning
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Positioning
 */
 import "C"

--- a/qt6/printsupport/cflags.go
+++ b/qt6/printsupport/cflags.go
@@ -1,6 +1,7 @@
 package printsupport
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6PrintSupport
 */
 import "C"

--- a/qt6/qml/cflags.go
+++ b/qt6/qml/cflags.go
@@ -1,6 +1,7 @@
 package qml
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Qml
 */
 import "C"

--- a/qt6/spatialaudio/cflags.go
+++ b/qt6/spatialaudio/cflags.go
@@ -1,6 +1,7 @@
 package spatialaudio
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6SpatialAudio
 */
 import "C"

--- a/qt6/sql/cflags.go
+++ b/qt6/sql/cflags.go
@@ -1,6 +1,7 @@
 package sql
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6Sql
 */
 import "C"

--- a/qt6/statemachine/cflags.go
+++ b/qt6/statemachine/cflags.go
@@ -1,6 +1,7 @@
 package statemachine
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6StateMachine Qt6StateMachineQml
 */
 import "C"

--- a/qt6/svg/cflags.go
+++ b/qt6/svg/cflags.go
@@ -1,6 +1,7 @@
 package svg
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6SvgWidgets
 */
 import "C"

--- a/qt6/uiplugin/cflags.go
+++ b/qt6/uiplugin/cflags.go
@@ -1,6 +1,7 @@
 package uiplugin
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6UiPlugin Qt6Designer
 */
 import "C"

--- a/qt6/uitools/cflags.go
+++ b/qt6/uitools/cflags.go
@@ -1,6 +1,7 @@
 package uitools
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6UiTools
 */
 import "C"

--- a/qt6/webchannel/cflags.go
+++ b/qt6/webchannel/cflags.go
@@ -1,6 +1,7 @@
 package webchannel
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6WebChannel
 */
 import "C"

--- a/qt6/webchannel/qmlwebchannel/cflags.go
+++ b/qt6/webchannel/qmlwebchannel/cflags.go
@@ -1,6 +1,7 @@
 package qmlwebchannel
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6WebChannel
 */
 import "C"

--- a/qt6/webengine/cflags.go
+++ b/qt6/webengine/cflags.go
@@ -1,6 +1,7 @@
 package webengine
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6WebEngineWidgets
 */
 import "C"

--- a/qt6/websockets/cflags.go
+++ b/qt6/websockets/cflags.go
@@ -1,7 +1,7 @@
 package websockets
 
 /*
+#cgo CXXFLAGS: -std=c++17
 #cgo pkg-config: Qt6WebSockets
 */
 import "C"
-


### PR DESCRIPTION
Fixes: #344 

We're setting CXXFLAGS=-std... for many generated packages, but not all of them. Standardize on always setting c++11 / C gnu11 for all Qt 5 packages, and, c++17 for all Qt 6 packages as per upstream's minimum supported version.

Add a bash script to lint this and run it in CI.