### PR TITLE
clangexec.go: Update input file language to C++ header

### DIFF
--- a/cmd/genbindings/clangexec.go
+++ b/cmd/genbindings/clangexec.go
@@ -8,7 +8,7 @@ import (
 )
 
 func clangExec(clangBin, inputHeader string, cflags []string) (*AstNode, error) {
-	clangArgs := []string{`-x`, `c++`}
+	clangArgs := []string{`-x`, `c++-header`}
 	clangArgs = append(clangArgs, cflags...)
 	clangArgs = append(clangArgs, `-Xclang`, `-ast-dump=json`, `-fsyntax-only`, inputHeader)
 


### PR DESCRIPTION
This addresses some of the warnings seen when processing the AST initially. The current language type flag specifies C++ source rather than C++ header.